### PR TITLE
Add missing views for compilation

### DIFF
--- a/GPS Logger/ActivityView.swift
+++ b/GPS Logger/ActivityView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import UIKit
+
+/// A wrapper for `UIActivityViewController` to present share sheets.
+struct ActivityView: UIViewControllerRepresentable {
+    var activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/GPS Logger/CompositeCameraView.swift
+++ b/GPS Logger/CompositeCameraView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import UIKit
+
+/// A simple camera view that saves captured image and overlay text.
+/// This is a minimal placeholder implementation and does not include
+/// advanced functionality.
+struct CompositeCameraView: UIViewControllerRepresentable {
+    @Binding var capturedCompositeImage: UIImage?
+    @Binding var capturedOverlayText: String
+    @EnvironmentObject var locationManager: LocationManager
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        var parent: CompositeCameraView
+
+        init(parent: CompositeCameraView) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.capturedCompositeImage = image
+                if let loc = parent.locationManager.lastLocation {
+                    parent.capturedOverlayText = String(format: "Lat: %.5f\nLon: %.5f", loc.coordinate.latitude, loc.coordinate.longitude)
+                }
+            }
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+}

--- a/GPS Logger/SettingsView.swift
+++ b/GPS Logger/SettingsView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// A screen to adjust parameters used by altitude filtering and logging.
+struct SettingsView: View {
+    @ObservedObject var settings: Settings
+
+    var body: some View {
+        Form {
+            Section(header: Text("Kalman Filter")) {
+                HStack {
+                    Text("Process Noise")
+                    Spacer()
+                    Text(String(format: "%.2f", settings.processNoise))
+                }
+                Slider(value: $settings.processNoise, in: 0...1, step: 0.05)
+
+                HStack {
+                    Text("Measurement Noise")
+                    Spacer()
+                    Text(String(format: "%.2f", settings.measurementNoise))
+                }
+                Slider(value: $settings.measurementNoise, in: 1...50, step: 0.5)
+            }
+
+            Section(header: Text("Logging")) {
+                HStack {
+                    Text("Interval (s)")
+                    Spacer()
+                    Text(String(format: "%.1f", settings.logInterval))
+                }
+                Slider(value: $settings.logInterval, in: 0.5...10, step: 0.5)
+
+                HStack {
+                    Text("Barometer Weight")
+                    Spacer()
+                    Text(String(format: "%.2f", settings.baroWeight))
+                }
+                Slider(value: $settings.baroWeight, in: 0...1, step: 0.05)
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView(settings: Settings())
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SettingsView` for editing app settings
- add `CompositeCameraView` as a placeholder camera capture view
- include `ActivityView` wrapper for share sheets

## Testing
- `swiftc -swift-version 5 -parse "GPS Logger/ActivityView.swift" "GPS Logger/AltitudeFusionManager.swift" "GPS Logger/CompositeCameraView.swift" "GPS Logger/ContentView.swift" "GPS Logger/Extensions.swift" "GPS Logger/FlightLog.swift" "GPS Logger/FlightLogManager.swift" "GPS Logger/GPS_LoggerApp.swift" "GPS Logger/KalmanFilter2D.swift" "GPS Logger/LocationManager.swift" "GPS Logger/Settings.swift" "GPS Logger/SettingsView.swift"`