### PR TITLE
Fix GPS altitude update and logging

### DIFF
--- a/GPS Logger/CompositeCameraView.swift
+++ b/GPS Logger/CompositeCameraView.swift
@@ -22,6 +22,12 @@ struct CompositeCameraView: UIViewControllerRepresentable {
                 if let loc = parent.locationManager.lastLocation {
                     parent.capturedOverlayText = String(format: "Lat: %.5f\nLon: %.5f", loc.coordinate.latitude, loc.coordinate.longitude)
                 }
+                if let index = parent.locationManager.recordPhotoCapture(),
+                   let folderURL = parent.locationManager.flightLogManager.sessionFolderURL,
+                   let data = image.jpegData(compressionQuality: 0.9) {
+                    let fileURL = folderURL.appendingPathComponent("Photo_\(index).jpg")
+                    try? data.write(to: fileURL)
+                }
             }
             picker.dismiss(animated: true)
         }

--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -87,30 +87,30 @@ struct ContentView: View {
                                 var mc = loc.course - locationManager.declination
                                 mc = mc.truncatingRemainder(dividingBy: 360)
                                 if mc < 0 { mc += 360 }
-                                return String(format: "%.2f°", mc)
+                                return String(format: "%.0f°", mc)
                             }
                         }()
                         
                         VStack(alignment: .leading, spacing: 5) {
                             Text("GPS受信時刻 (JST): \(loc.timestamp, formatter: jstFormatter)")
                             Text("緯度: \(loc.coordinate.latitude.toDegMin())  経度: \(loc.coordinate.longitude.toDegMin())").padding(.top, 4)
-                            Text(String(format: "水平誤差: ±%.2f m", loc.horizontalAccuracy))
+                            Text(String(format: "水平誤差: ±%.1f m", loc.horizontalAccuracy))
                             Text("磁方位: \(magneticText)").font(.title)
-                            Text(String(format: "速度: %.2f kt", loc.speed * 1.94384)).font(.title)
-                            Text(String(format: "GPS 高度: %.2f ft", locationManager.rawGpsAltitude)).font(.title).padding(.top, 40)
+                            Text(String(format: "速度: %.1f kt", loc.speed * 1.94384)).font(.title)
+                            Text(String(format: "GPS 高度: %.1f ft", locationManager.rawGpsAltitude)).font(.title).padding(.top, 40)
                             
                             if let fusedAlt = altitudeFusionManager.fusedAltitude {
-                                Text(String(format: "高度 (Kalman): %.2f ft", fusedAlt))
+                                Text(String(format: "高度 (Kalman): %.1f ft", fusedAlt))
                             } else {
-                                Text(String(format: "高度: %.2f ft", loc.altitude * 3.28084))
+                                Text(String(format: "高度: %.1f ft", loc.altitude * 3.28084))
                             }
-                            Text(String(format: "垂直誤差: ±%.2f ft", loc.verticalAccuracy * 3.28084))
+                            Text(String(format: "垂直誤差: ±%.1f ft", loc.verticalAccuracy * 3.28084))
                                 .font(.title)
                                 .padding(.bottom, 40)
                                 .foregroundColor(verticalErrorColor(for: loc.verticalAccuracy * 3.28084))
-                            Text(String(format: "GPS 高度変化率: %.2f ft/min", locationManager.rawGpsAltitudeChangeRate))
+                            Text(String(format: "GPS 高度変化率: %.1f ft/min", locationManager.rawGpsAltitudeChangeRate))
 
-                            Text(String(format: "高度変化率 (Kalman): %.2f ft/min", altitudeFusionManager.altitudeChangeRate))
+                            Text(String(format: "高度変化率 (Kalman): %.1f ft/min", altitudeFusionManager.altitudeChangeRate))
 
 
                         }
@@ -136,6 +136,7 @@ struct ContentView: View {
                                     shareItems = [csvURL]
                                     showingShareSheet = true
                                 }
+                                flightLogManager.endSession()
                             }
                             .font(.title2)
                             .frame(width: 150, height: 60)

--- a/GPS Logger/Extensions.swift
+++ b/GPS Logger/Extensions.swift
@@ -5,6 +5,6 @@ extension Double {
     func toDegMin() -> String {
         let degrees = Int(self)
         let minutes = (self - Double(degrees)) * 60
-        return "\(degrees)°\(String(format: "%.5f", minutes))'"
+        return "\(degrees)°\(String(format: "%.3f", minutes))'"
     }
 }

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -98,7 +98,6 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         logTimer?.invalidate()
         logTimer = nil
         altitudeFusionManager.stopUpdates()
-        flightLogManager.endSession()
     }
 
     func recordPhotoCapture() -> Int? {
@@ -108,8 +107,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         return photoCounter
     }
 
-    func recordLog() {
-        guard let loc = lastLocation else { return }
+    private func updateAltitude(with loc: CLLocation) {
         let altitudeFt = loc.altitude * 3.28084
         let now = Date()
         var vspeed = rawGpsAltitudeChangeRate
@@ -127,6 +125,13 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         altitudeFusionManager.rawGpsVerticalSpeed = vspeed
         altitudeFusionManager.gpsVerticalAccuracy = loc.verticalAccuracy * 3.28084
         altitudeFusionManager.startUpdates(gpsAltitude: altitudeFt)
+    }
+
+    func recordLog() {
+        guard let loc = lastLocation else { return }
+        let altitudeFt = rawGpsAltitude
+        let vspeed = rawGpsAltitudeChangeRate
+        let now = Date()
 
         let log = FlightLog(timestamp: now,
                              latitude: loc.coordinate.latitude,
@@ -157,6 +162,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         guard let latest = locations.last else { return }
         DispatchQueue.main.async {
             self.lastLocation = latest
+            self.updateAltitude(with: latest)
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure GPS altitude updates even when not recording
- export logs before ending session
- store captured photos in log folder
- reduce displayed precision for key values

## Testing
- `git status --short`