### PR TITLE
Add title to navigation view

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -244,6 +244,7 @@ struct ContentView: View {
                 }
                 .padding()
             }
+            .navigationTitle("GPS Logger")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink(destination: SettingsView(settings: settings)) {


### PR DESCRIPTION
## Summary
- add a `navigationTitle` to ContentView so the main view has a title

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*