### PR TITLE
Add measurement log export

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
     @State private var showingDistanceGraph = false
     @State private var graphLogs: [FlightLog] = []
     @State private var lastMeasurement: DistanceMeasurement?
+    @State private var measurementLogURL: URL?
     
     // UI表示用のサンプルデータ
     @State var gpsTime: String = "12:34:56"
@@ -159,12 +160,15 @@ struct ContentView: View {
                                         graphLogs = flightLogManager.flightLogs.filter { log in
                                             log.timestamp >= result.startTime && log.timestamp <= result.endTime
                                         }
+                                        measurementLogURL = flightLogManager.exportMeasurementLogs(for: result,
+                                                                                                  logs: graphLogs)
                                         lastMeasurement = result
                                         showingDistanceGraph = true
                                         measurementResultMessage = nil
                                     } else {
                                         measurementResultMessage = "計測に失敗しました"
                                         showingMeasurementAlert = true
+                                        measurementLogURL = nil
                                     }
                                     measuringDistance = false
                                     measurementStart = nil
@@ -174,6 +178,7 @@ struct ContentView: View {
                                     flightLogManager.startMeasurement(at: start)
                                     measuringDistance = true
                                     measurementResultMessage = nil
+                                    measurementLogURL = nil
                                 }
                             }
                             .font(.title2)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# GPS Logger
+
+This project records flight log data using Core Location and sensor fusion.
+Each recording session saves logs in a uniquely timestamped folder inside the
+app's document directory.
+
+## Measurement Logs
+
+When you perform a distance measurement, the logs used to generate the altitude
+chart are exported automatically. A CSV file named
+`MeasurementLog_YYYYMMDD_HHmmss.csv` is written inside the same session folder
+as the regular flight log CSVs. Each row contains the timestamp, GPS altitude,
+Kalman‑fused altitude and corresponding change rates for that measurement.
+
+These measurement logs make it easy to review altitude changes for a specific
+distance measurement alongside the overall flight log.


### PR DESCRIPTION
## Summary
- add `exportMeasurementLogs(for:logs:)` to FlightLogManager
- export measurement logs after finishing a measurement
- keep latest measurement log URL in ContentView
- document measurement log export in README

## Testing
- `swiftc -typecheck "GPS Logger/FlightLogManager.swift" "GPS Logger/ContentView.swift"` *(fails: no such module 'Combine')*