### PR TITLE
Save altitude chart as PNG

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
     @State private var graphLogs: [FlightLog] = []
     @State private var lastMeasurement: DistanceMeasurement?
     @State private var measurementLogURL: URL?
+    @State private var measurementGraphURL: URL?
     
     // UI表示用のサンプルデータ
     @State var gpsTime: String = "12:34:56"
@@ -161,7 +162,16 @@ struct ContentView: View {
                                             log.timestamp >= result.startTime && log.timestamp <= result.endTime
                                         }
                                         measurementLogURL = flightLogManager.exportMeasurementLogs(for: result,
-                                                                                                  logs: graphLogs)
+                                                                                                 logs: graphLogs)
+
+                                        let graphView = DistanceGraphView(logs: graphLogs, measurement: result)
+                                        if let image = graphView.chartImage() {
+                                            measurementGraphURL = flightLogManager.exportMeasurementGraphImage(for: result,
+                                                                                                             chartImage: image)
+                                        } else {
+                                            measurementGraphURL = nil
+                                        }
+
                                         lastMeasurement = result
                                         showingDistanceGraph = true
                                         measurementResultMessage = nil
@@ -169,6 +179,7 @@ struct ContentView: View {
                                         measurementResultMessage = "計測に失敗しました"
                                         showingMeasurementAlert = true
                                         measurementLogURL = nil
+                                        measurementGraphURL = nil
                                     }
                                     measuringDistance = false
                                     measurementStart = nil
@@ -179,6 +190,7 @@ struct ContentView: View {
                                     measuringDistance = true
                                     measurementResultMessage = nil
                                     measurementLogURL = nil
+                                    measurementGraphURL = nil
                                 }
                             }
                             .font(.title2)

--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Charts
+import UIKit
 
 /// Displays altitude over time for a distance measurement.
 struct DistanceGraphView: View {
@@ -40,6 +41,13 @@ struct DistanceGraphView: View {
             }
         }
         .frame(height: 240)
+    }
+
+    /// Render the altitude chart to a `UIImage` for export.
+    func chartImage() -> UIImage? {
+        let renderer = ImageRenderer(content: altitudeChart)
+        renderer.scale = UIScreen.main.scale
+        return renderer.uiImage
     }
 }
 

--- a/GPS Logger/FlightLogManager.swift
+++ b/GPS Logger/FlightLogManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import CoreLocation
+import UIKit
 
 /// Handles storage and export of flight log entries.
 final class FlightLogManager: ObservableObject {
@@ -206,6 +207,29 @@ final class FlightLogManager: ObservableObject {
             combined.append(bom)
             combined.append(csvData)
             try? combined.write(to: fileURL, options: .atomic)
+            return fileURL
+        }
+
+        return nil
+    }
+
+    /// Export an altitude chart image for a specific measurement.
+    /// - Parameters:
+    ///   - measurement: The associated distance measurement.
+    ///   - chartImage: Image created from `DistanceGraphView`.
+    /// - Returns: URL of the saved PNG if successful.
+    func exportMeasurementGraphImage(for measurement: DistanceMeasurement,
+                                     chartImage: UIImage) -> URL? {
+        guard let folderURL = sessionFolderURL else { return nil }
+
+        let nameFormatter = DateFormatter()
+        nameFormatter.dateFormat = "yyyyMMdd_HHmmss"
+        let name = nameFormatter.string(from: measurement.startTime)
+        let fileName = "MeasurementGraph_\(name).png"
+        let fileURL = folderURL.appendingPathComponent(fileName)
+
+        if let data = chartImage.pngData() {
+            try? data.write(to: fileURL, options: .atomic)
             return fileURL
         }
 


### PR DESCRIPTION
## Summary
- add helper to render altitude chart as image
- save distance measurement chart image from `FlightLogManager`
- capture chart in `ContentView` when showing graph

## Testing
- `true`