### PR TITLE
Replace NavigationView with NavigationStack

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
     @State private var lastMeasurement: DistanceMeasurement?
     @State private var measurementLogURL: URL?
     @State private var measurementGraphURL: URL?
+    @State private var showSettings = false
     
     // UI表示用のサンプルデータ
     @State var gpsTime: String = "12:34:56"
@@ -80,7 +81,7 @@ struct ContentView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
                 VStack(spacing: 40) {
                     Text("現在時刻 (JST): \(currentTime, formatter: jstFormatter)")
                         .font(.title)
@@ -263,9 +264,16 @@ struct ContentView: View {
             }
             .navigationTitle("GPS Logger")
             .navigationBarTitleDisplayMode(.inline)
+            .background(
+                NavigationLink(destination: SettingsView(settings: settings), isActive: $showSettings) {
+                    EmptyView()
+                }
+            )
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    NavigationLink(destination: SettingsView(settings: settings)) {
+                    Button {
+                        showSettings = true
+                    } label: {
                         Label("設定", systemImage: "gearshape")
                     }
                 }
@@ -288,7 +296,7 @@ struct ContentView: View {
             }
             .sheet(isPresented: $showingDistanceGraph) {
                 if let measurement = lastMeasurement {
-                    NavigationView {
+                    NavigationStack {
                         DistanceGraphView(logs: graphLogs, measurement: measurement)
                     }
                 }

--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -86,7 +86,7 @@ struct DistanceGraphView_Previews: PreviewProvider {
                 photoIndex: nil
             )
         }
-        NavigationView {
+        NavigationStack {
             DistanceGraphView(logs: logs, measurement: measurement)
         }
     }


### PR DESCRIPTION
## Summary
- adopt `NavigationStack` in `ContentView`
- update sheet and previews to use `NavigationStack`
- fix Settings navigation via programmatic link

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*