### PR TITLE
Add recording options for extra flight log fields

### DIFF
--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -33,11 +33,13 @@ struct DistanceGraphView: View {
                 .foregroundStyle(.red)
             }
             ForEach(logs) { log in
-                LineMark(
-                    x: .value("Time", log.timestamp),
-                    y: .value("Kalman Altitude", log.fusedAltitude)
-                )
-                .foregroundStyle(.blue)
+                if let fused = log.fusedAltitude {
+                    LineMark(
+                        x: .value("Time", log.timestamp),
+                        y: .value("Kalman Altitude", fused)
+                    )
+                    .foregroundStyle(.blue)
+                }
             }
         }
         .frame(height: 240)

--- a/GPS Logger/FlightLog.swift
+++ b/GPS Logger/FlightLog.swift
@@ -16,12 +16,12 @@ struct FlightLog: Identifiable {
     let altimeterPressure: Double?    // optional
 
     // Sensor / fusion related data
-    let rawGpsAltitudeChangeRate: Double   // ft/min
-    let relativeAltitude: Double           // ft
-    let barometricAltitude: Double         // ft
+    let rawGpsAltitudeChangeRate: Double?   // ft/min
+    let relativeAltitude: Double?           // ft
+    let barometricAltitude: Double?         // ft
     let latestAcceleration: Double?        // ft/s²
-    let fusedAltitude: Double              // ft
-    let fusedAltitudeChangeRate: Double    // ft/min
+    let fusedAltitude: Double?              // ft
+    let fusedAltitudeChangeRate: Double?    // ft/min
 
     // Parameters used for log optimisation
     let baselineAltitude: Double?          // initial GPS altitude

--- a/GPS Logger/FlightLogManager.swift
+++ b/GPS Logger/FlightLogManager.swift
@@ -123,11 +123,18 @@ final class FlightLogManager: ObservableObject {
         let fileName = "FlightLog_\(Int(Date().timeIntervalSince1970)).csv"
         let fileURL = folderURL.appendingPathComponent(fileName)
 
-        var headers = ["timestamp","latitude","longitude","gpsAltitude(ft)"]
-        if settings.recordSpeed { headers.append("speed(kt)") }
-        headers.append(contentsOf: ["magneticCourse","horizontalAccuracy(m)","verticalAccuracy(ft)","altimeterPressure","rawGpsAltitudeChangeRate(ft/min)","relativeAltitude(ft)","barometricAltitude(ft)"])
+        var headers = ["timestamp","latitude","longitude","gpsAltitude(ft)","speed(kt)","magneticCourse","horizontalAccuracy(m)","verticalAccuracy(ft)"]
+        if settings.recordAltimeterPressure { headers.append("altimeterPressure") }
+        if settings.recordRawGpsRate { headers.append("rawGpsAltitudeChangeRate(ft/min)") }
+        if settings.recordRelativeAltitude { headers.append("relativeAltitude(ft)") }
+        if settings.recordBarometricAltitude { headers.append("barometricAltitude(ft)") }
         if settings.recordAcceleration { headers.append("latestAcceleration(ft/s²)") }
-        headers.append(contentsOf: ["fusedAltitude(ft)","fusedAltitudeChangeRate(ft/min)","baselineAltitude(ft)","measuredAltitude(ft)","kalmanUpdateInterval(s)","photoIndex"])
+        if settings.recordFusedAltitude { headers.append("fusedAltitude(ft)") }
+        if settings.recordFusedRate { headers.append("fusedAltitudeChangeRate(ft/min)") }
+        if settings.recordBaselineAltitude { headers.append("baselineAltitude(ft)") }
+        if settings.recordMeasuredAltitude { headers.append("measuredAltitude(ft)") }
+        if settings.recordKalmanInterval { headers.append("kalmanUpdateInterval(s)") }
+        headers.append("photoIndex")
         var csvText = headers.joined(separator: ",") + "\n"
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -135,11 +142,18 @@ final class FlightLogManager: ObservableObject {
         for log in flightLogs {
             let ts = isoFormatter.string(from: log.timestamp)
             let photoIndexText = log.photoIndex.map(String.init) ?? ""
-            var row = ["\(ts)","\(log.latitude)","\(log.longitude)","\(log.gpsAltitude)"]
-            if settings.recordSpeed { row.append("\(log.speedKt ?? 0)") }
-            row.append(contentsOf: ["\(log.magneticCourse)","\(log.horizontalAccuracyM)","\(log.verticalAccuracyFt)","\(log.altimeterPressure ?? 0)","\(log.rawGpsAltitudeChangeRate)","\(log.relativeAltitude)","\(log.barometricAltitude)"])
+            var row = ["\(ts)","\(log.latitude)","\(log.longitude)","\(log.gpsAltitude)","\(log.speedKt ?? 0)","\(log.magneticCourse)","\(log.horizontalAccuracyM)","\(log.verticalAccuracyFt)"]
+            if settings.recordAltimeterPressure { row.append("\(log.altimeterPressure ?? 0)") }
+            if settings.recordRawGpsRate { row.append("\(log.rawGpsAltitudeChangeRate ?? 0)") }
+            if settings.recordRelativeAltitude { row.append("\(log.relativeAltitude ?? 0)") }
+            if settings.recordBarometricAltitude { row.append("\(log.barometricAltitude ?? 0)") }
             if settings.recordAcceleration { row.append("\(log.latestAcceleration ?? 0)") }
-            row.append(contentsOf: ["\(log.fusedAltitude)","\(log.fusedAltitudeChangeRate)","\(log.baselineAltitude ?? 0)","\(log.measuredAltitude ?? 0)","\(log.kalmanUpdateInterval ?? 0)","\(photoIndexText)"])
+            if settings.recordFusedAltitude { row.append("\(log.fusedAltitude ?? 0)") }
+            if settings.recordFusedRate { row.append("\(log.fusedAltitudeChangeRate ?? 0)") }
+            if settings.recordBaselineAltitude { row.append("\(log.baselineAltitude ?? 0)") }
+            if settings.recordMeasuredAltitude { row.append("\(log.measuredAltitude ?? 0)") }
+            if settings.recordKalmanInterval { row.append("\(log.kalmanUpdateInterval ?? 0)") }
+            row.append(photoIndexText)
             csvText.append(row.joined(separator: ",") + "\n")
         }
 
@@ -193,13 +207,21 @@ final class FlightLogManager: ObservableObject {
         let fileName = "MeasurementLog_\(nameFormatter.string(from: Date())).csv"
         let fileURL = folderURL.appendingPathComponent(fileName)
 
-        var csvText = "timestamp,gpsAltitude(ft),fusedAltitude(ft),rawGpsAltitudeChangeRate(ft/min),fusedAltitudeChangeRate(ft/min)\n"
+        var headers = ["timestamp","gpsAltitude(ft)"]
+        if settings.recordFusedAltitude { headers.append("fusedAltitude(ft)") }
+        if settings.recordRawGpsRate { headers.append("rawGpsAltitudeChangeRate(ft/min)") }
+        if settings.recordFusedRate { headers.append("fusedAltitudeChangeRate(ft/min)") }
+        var csvText = headers.joined(separator: ",") + "\n"
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         isoFormatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
         for log in logs {
             let ts = isoFormatter.string(from: log.timestamp)
-            csvText.append("\(ts),\(log.gpsAltitude),\(log.fusedAltitude),\(log.rawGpsAltitudeChangeRate),\(log.fusedAltitudeChangeRate)\n")
+            var row = ["\(ts)","\(log.gpsAltitude)"]
+            if settings.recordFusedAltitude { row.append("\(log.fusedAltitude ?? 0)") }
+            if settings.recordRawGpsRate { row.append("\(log.rawGpsAltitudeChangeRate ?? 0)") }
+            if settings.recordFusedRate { row.append("\(log.fusedAltitudeChangeRate ?? 0)") }
+            csvText.append(row.joined(separator: ",") + "\n")
         }
 
         if let bom = "\u{FEFF}".data(using: .utf8), let csvData = csvText.data(using: .utf8) {

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -132,7 +132,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         let altitudeFt = rawGpsAltitude
         let now = Date()
 
-        let speedKt = settings.recordSpeed ? loc.speed * 1.94384 : nil
+        let speedKt: Double? = {
+            let spd = loc.speed
+            return spd >= 0 ? spd * 1.94384 : nil
+        }()
         let latestAcc = settings.recordAcceleration ? altitudeFusionManager.latestAcceleration : nil
 
         let log = FlightLog(timestamp: now,
@@ -143,16 +146,16 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                              magneticCourse: loc.course,
                              horizontalAccuracyM: loc.horizontalAccuracy,
                              verticalAccuracyFt: loc.verticalAccuracy * 3.28084,
-                             altimeterPressure: altitudeFusionManager.altimeterPressure,
-                             rawGpsAltitudeChangeRate: rawGpsAltitudeChangeRate,
-                             relativeAltitude: altitudeFusionManager.relativeAltitude ?? 0,
-                             barometricAltitude: altitudeFusionManager.baselineAltitude.map { $0 + (altitudeFusionManager.relativeAltitude ?? 0) } ?? altitudeFt,
+                             altimeterPressure: settings.recordAltimeterPressure ? altitudeFusionManager.altimeterPressure : nil,
+                             rawGpsAltitudeChangeRate: settings.recordRawGpsRate ? rawGpsAltitudeChangeRate : nil,
+                             relativeAltitude: settings.recordRelativeAltitude ? altitudeFusionManager.relativeAltitude : nil,
+                             barometricAltitude: settings.recordBarometricAltitude ? altitudeFusionManager.baselineAltitude.map { $0 + (altitudeFusionManager.relativeAltitude ?? 0) } ?? altitudeFt : nil,
                              latestAcceleration: latestAcc,
-                             fusedAltitude: altitudeFusionManager.fusedAltitude ?? altitudeFt,
-                             fusedAltitudeChangeRate: altitudeFusionManager.altitudeChangeRate,
-                             baselineAltitude: altitudeFusionManager.baselineAltitude,
-                             measuredAltitude: altitudeFusionManager.measuredAltitude,
-                             kalmanUpdateInterval: altitudeFusionManager.kalmanUpdateInterval,
+                             fusedAltitude: settings.recordFusedAltitude ? (altitudeFusionManager.fusedAltitude ?? altitudeFt) : nil,
+                             fusedAltitudeChangeRate: settings.recordFusedRate ? altitudeFusionManager.altitudeChangeRate : nil,
+                             baselineAltitude: settings.recordBaselineAltitude ? altitudeFusionManager.baselineAltitude : nil,
+                             measuredAltitude: settings.recordMeasuredAltitude ? altitudeFusionManager.measuredAltitude : nil,
+                             kalmanUpdateInterval: settings.recordKalmanInterval ? altitudeFusionManager.kalmanUpdateInterval : nil,
                              photoIndex: pendingPhotoIndex)
         pendingPhotoIndex = nil
         flightLogManager.addLog(log)

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -17,11 +17,35 @@ final class Settings: ObservableObject {
     }
 
     // Recording options
-    @Published var recordSpeed: Bool {
-        didSet { UserDefaults.standard.set(recordSpeed, forKey: "recordSpeed") }
-    }
     @Published var recordAcceleration: Bool {
         didSet { UserDefaults.standard.set(recordAcceleration, forKey: "recordAcceleration") }
+    }
+    @Published var recordAltimeterPressure: Bool {
+        didSet { UserDefaults.standard.set(recordAltimeterPressure, forKey: "recordAltimeterPressure") }
+    }
+    @Published var recordRawGpsRate: Bool {
+        didSet { UserDefaults.standard.set(recordRawGpsRate, forKey: "recordRawGpsRate") }
+    }
+    @Published var recordRelativeAltitude: Bool {
+        didSet { UserDefaults.standard.set(recordRelativeAltitude, forKey: "recordRelativeAltitude") }
+    }
+    @Published var recordBarometricAltitude: Bool {
+        didSet { UserDefaults.standard.set(recordBarometricAltitude, forKey: "recordBarometricAltitude") }
+    }
+    @Published var recordFusedAltitude: Bool {
+        didSet { UserDefaults.standard.set(recordFusedAltitude, forKey: "recordFusedAltitude") }
+    }
+    @Published var recordFusedRate: Bool {
+        didSet { UserDefaults.standard.set(recordFusedRate, forKey: "recordFusedRate") }
+    }
+    @Published var recordBaselineAltitude: Bool {
+        didSet { UserDefaults.standard.set(recordBaselineAltitude, forKey: "recordBaselineAltitude") }
+    }
+    @Published var recordMeasuredAltitude: Bool {
+        didSet { UserDefaults.standard.set(recordMeasuredAltitude, forKey: "recordMeasuredAltitude") }
+    }
+    @Published var recordKalmanInterval: Bool {
+        didSet { UserDefaults.standard.set(recordKalmanInterval, forKey: "recordKalmanInterval") }
     }
 
     init() {
@@ -29,7 +53,15 @@ final class Settings: ObservableObject {
         measurementNoise = UserDefaults.standard.object(forKey: "measurementNoise") as? Double ?? 15.0
         logInterval = UserDefaults.standard.object(forKey: "logInterval") as? Double ?? 1.0
         baroWeight = UserDefaults.standard.object(forKey: "baroWeight") as? Double ?? 0.75
-        recordSpeed = UserDefaults.standard.object(forKey: "recordSpeed") as? Bool ?? true
         recordAcceleration = UserDefaults.standard.object(forKey: "recordAcceleration") as? Bool ?? true
+        recordAltimeterPressure = UserDefaults.standard.object(forKey: "recordAltimeterPressure") as? Bool ?? true
+        recordRawGpsRate = UserDefaults.standard.object(forKey: "recordRawGpsRate") as? Bool ?? true
+        recordRelativeAltitude = UserDefaults.standard.object(forKey: "recordRelativeAltitude") as? Bool ?? true
+        recordBarometricAltitude = UserDefaults.standard.object(forKey: "recordBarometricAltitude") as? Bool ?? true
+        recordFusedAltitude = UserDefaults.standard.object(forKey: "recordFusedAltitude") as? Bool ?? true
+        recordFusedRate = UserDefaults.standard.object(forKey: "recordFusedRate") as? Bool ?? true
+        recordBaselineAltitude = UserDefaults.standard.object(forKey: "recordBaselineAltitude") as? Bool ?? true
+        recordMeasuredAltitude = UserDefaults.standard.object(forKey: "recordMeasuredAltitude") as? Bool ?? true
+        recordKalmanInterval = UserDefaults.standard.object(forKey: "recordKalmanInterval") as? Bool ?? true
     }
 }

--- a/GPS Logger/SettingsView.swift
+++ b/GPS Logger/SettingsView.swift
@@ -39,8 +39,16 @@ struct SettingsView: View {
             }
 
             Section(header: Text("Recorded Fields")) {
-                Toggle("Record Speed", isOn: $settings.recordSpeed)
                 Toggle("Record Acceleration", isOn: $settings.recordAcceleration)
+                Toggle("Record Altimeter Pressure", isOn: $settings.recordAltimeterPressure)
+                Toggle("Record Raw GPS Rate", isOn: $settings.recordRawGpsRate)
+                Toggle("Record Relative Altitude", isOn: $settings.recordRelativeAltitude)
+                Toggle("Record Barometric Altitude", isOn: $settings.recordBarometricAltitude)
+                Toggle("Record Fused Altitude", isOn: $settings.recordFusedAltitude)
+                Toggle("Record Fused Rate", isOn: $settings.recordFusedRate)
+                Toggle("Record Baseline Altitude", isOn: $settings.recordBaselineAltitude)
+                Toggle("Record Measured Altitude", isOn: $settings.recordMeasuredAltitude)
+                Toggle("Record Kalman Interval", isOn: $settings.recordKalmanInterval)
             }
         }
         .navigationTitle("Settings")


### PR DESCRIPTION
## Summary
- expand Settings to store optional field preferences
- show toggles for new options in SettingsView
- always log speed and make remaining fields optional
- adjust FlightLog to hold optionals
- use options when recording and exporting logs
- skip optional columns in measurement exports

## Testing
- `swift test` *(fails: Could not find Package.swift)*