### PR TITLE
Clear ring buffer after saving frames

### DIFF
--- a/GPS Logger/CameraSessionManager.swift
+++ b/GPS Logger/CameraSessionManager.swift
@@ -91,6 +91,11 @@ class CameraSessionManager: NSObject {
                 try? data.write(to: url)
             }
         }
+        // Clear any frames that were just saved so previous captures are not
+        // mixed into the next shutter event.
+        queue.sync {
+            ringBuffer.removeAll()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- clear the camera session's ring buffer after saving the buffered frames

## Testing
- `swift test --list-tests` *(fails: Could not find Package.swift)*