### PR TITLE
Refactor Settings with UserDefaults-backed wrapper

### DIFF
--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -3,65 +3,22 @@ import Combine
 
 /// Stores adjustable parameters for altitude filtering.
 final class Settings: ObservableObject {
-    @Published var processNoise: Double {
-        didSet { UserDefaults.standard.set(processNoise, forKey: "processNoise") }
-    }
-    @Published var measurementNoise: Double {
-        didSet { UserDefaults.standard.set(measurementNoise, forKey: "measurementNoise") }
-    }
-    @Published var logInterval: Double {
-        didSet { UserDefaults.standard.set(logInterval, forKey: "logInterval") }
-    }
-    @Published var baroWeight: Double {
-        didSet { UserDefaults.standard.set(baroWeight, forKey: "baroWeight") }
-    }
+    @UserDefaultBacked(key: "processNoise") var processNoise: Double = 0.2
+    @UserDefaultBacked(key: "measurementNoise") var measurementNoise: Double = 15.0
+    @UserDefaultBacked(key: "logInterval") var logInterval: Double = 1.0
+    @UserDefaultBacked(key: "baroWeight") var baroWeight: Double = 0.75
 
     // Recording options
-    @Published var recordAcceleration: Bool {
-        didSet { UserDefaults.standard.set(recordAcceleration, forKey: "recordAcceleration") }
-    }
-    @Published var recordAltimeterPressure: Bool {
-        didSet { UserDefaults.standard.set(recordAltimeterPressure, forKey: "recordAltimeterPressure") }
-    }
-    @Published var recordRawGpsRate: Bool {
-        didSet { UserDefaults.standard.set(recordRawGpsRate, forKey: "recordRawGpsRate") }
-    }
-    @Published var recordRelativeAltitude: Bool {
-        didSet { UserDefaults.standard.set(recordRelativeAltitude, forKey: "recordRelativeAltitude") }
-    }
-    @Published var recordBarometricAltitude: Bool {
-        didSet { UserDefaults.standard.set(recordBarometricAltitude, forKey: "recordBarometricAltitude") }
-    }
-    @Published var recordFusedAltitude: Bool {
-        didSet { UserDefaults.standard.set(recordFusedAltitude, forKey: "recordFusedAltitude") }
-    }
-    @Published var recordFusedRate: Bool {
-        didSet { UserDefaults.standard.set(recordFusedRate, forKey: "recordFusedRate") }
-    }
-    @Published var recordBaselineAltitude: Bool {
-        didSet { UserDefaults.standard.set(recordBaselineAltitude, forKey: "recordBaselineAltitude") }
-    }
-    @Published var recordMeasuredAltitude: Bool {
-        didSet { UserDefaults.standard.set(recordMeasuredAltitude, forKey: "recordMeasuredAltitude") }
-    }
-    @Published var recordKalmanInterval: Bool {
-        didSet { UserDefaults.standard.set(recordKalmanInterval, forKey: "recordKalmanInterval") }
-    }
+    @UserDefaultBacked(key: "recordAcceleration") var recordAcceleration: Bool = true
+    @UserDefaultBacked(key: "recordAltimeterPressure") var recordAltimeterPressure: Bool = true
+    @UserDefaultBacked(key: "recordRawGpsRate") var recordRawGpsRate: Bool = true
+    @UserDefaultBacked(key: "recordRelativeAltitude") var recordRelativeAltitude: Bool = true
+    @UserDefaultBacked(key: "recordBarometricAltitude") var recordBarometricAltitude: Bool = true
+    @UserDefaultBacked(key: "recordFusedAltitude") var recordFusedAltitude: Bool = true
+    @UserDefaultBacked(key: "recordFusedRate") var recordFusedRate: Bool = true
+    @UserDefaultBacked(key: "recordBaselineAltitude") var recordBaselineAltitude: Bool = true
+    @UserDefaultBacked(key: "recordMeasuredAltitude") var recordMeasuredAltitude: Bool = true
+    @UserDefaultBacked(key: "recordKalmanInterval") var recordKalmanInterval: Bool = true
 
-    init() {
-        processNoise = UserDefaults.standard.object(forKey: "processNoise") as? Double ?? 0.2
-        measurementNoise = UserDefaults.standard.object(forKey: "measurementNoise") as? Double ?? 15.0
-        logInterval = UserDefaults.standard.object(forKey: "logInterval") as? Double ?? 1.0
-        baroWeight = UserDefaults.standard.object(forKey: "baroWeight") as? Double ?? 0.75
-        recordAcceleration = UserDefaults.standard.object(forKey: "recordAcceleration") as? Bool ?? true
-        recordAltimeterPressure = UserDefaults.standard.object(forKey: "recordAltimeterPressure") as? Bool ?? true
-        recordRawGpsRate = UserDefaults.standard.object(forKey: "recordRawGpsRate") as? Bool ?? true
-        recordRelativeAltitude = UserDefaults.standard.object(forKey: "recordRelativeAltitude") as? Bool ?? true
-        recordBarometricAltitude = UserDefaults.standard.object(forKey: "recordBarometricAltitude") as? Bool ?? true
-        recordFusedAltitude = UserDefaults.standard.object(forKey: "recordFusedAltitude") as? Bool ?? true
-        recordFusedRate = UserDefaults.standard.object(forKey: "recordFusedRate") as? Bool ?? true
-        recordBaselineAltitude = UserDefaults.standard.object(forKey: "recordBaselineAltitude") as? Bool ?? true
-        recordMeasuredAltitude = UserDefaults.standard.object(forKey: "recordMeasuredAltitude") as? Bool ?? true
-        recordKalmanInterval = UserDefaults.standard.object(forKey: "recordKalmanInterval") as? Bool ?? true
-    }
+    init() {}
 }

--- a/GPS Logger/UserDefaultBacked.swift
+++ b/GPS Logger/UserDefaultBacked.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Combine
+
+/// A property wrapper that synchronizes a value with UserDefaults and publishes changes.
+@propertyWrapper
+struct UserDefaultBacked<Value> {
+    private let key: String
+    private let defaultValue: Value
+    @Published private var value: Value
+
+    var wrappedValue: Value {
+        get { value }
+        set {
+            value = newValue
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+
+    var projectedValue: Published<Value>.Publisher { $value }
+
+    init(wrappedValue defaultValue: Value, key: String) {
+        self.key = key
+        self.defaultValue = defaultValue
+        let stored = UserDefaults.standard.object(forKey: key) as? Value ?? defaultValue
+        self._value = Published(initialValue: stored)
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserDefaultBacked` wrapper for storing values in `UserDefaults`
- refactor `Settings` properties to use the new wrapper

## Testing
- `swift test` *(fails: Could not find Package.swift)*