### PR TITLE
Hide current time when GPS timestamp matches

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -84,9 +84,19 @@ struct ContentView: View {
         NavigationStack {
             ZStack {
                 VStack(spacing: 40) {
-                    Text("現在時刻 (JST): \(currentTime, formatter: jstFormatter)")
-                        .font(.title)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    let showCurrentTime: Bool = {
+                        if let loc = locationManager.lastLocation {
+                            return abs(currentTime.timeIntervalSince(loc.timestamp)) > 1
+                        } else {
+                            return true
+                        }
+                    }()
+
+                    if showCurrentTime {
+                        Text("現在時刻 (JST): \(currentTime, formatter: jstFormatter)")
+                            .font(.title)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                     
                     if let loc = locationManager.lastLocation {
                         let timeDiff = currentTime.timeIntervalSince(loc.timestamp)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "GPSLogger",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .library(name: "GPS_Logger", targets: ["GPS_Logger"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-testing.git", from: "0.3.0")
+    ],
+    targets: [
+        .target(
+            name: "GPS_Logger",
+            path: "GPS Logger",
+            resources: [
+                .process("Assets.xcassets"),
+                .process("Preview Content")
+            ]
+        ),
+        .testTarget(
+            name: "GPS_LoggerTests",
+            dependencies: [
+                "GPS_Logger",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "GPS LoggerTests"
+        )
+        // UI tests are not included in SPM
+    ]
+)


### PR DESCRIPTION
## Summary
- hide the local current time label if it matches the latest GPS timestamp
- add a Swift Package manifest for local builds

## Testing
- `swift test -c debug` *(fails to fetch swift-testing dependency: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683bfc4203408326987a43925b282d7f