### PR TITLE
Implement basic wind input UI and assist view

### DIFF
--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -90,7 +90,10 @@ struct DistanceGraphView_Previews: PreviewProvider {
                 theoreticalHP: nil,
                 deltaCAS: nil,
                 deltaHP: nil,
-                photoIndex: nil
+                photoIndex: nil,
+                windDirection: nil,
+                windSpeed: nil,
+                windSource: nil
             )
         }
         NavigationStack {

--- a/GPS Logger/FlightLog.swift
+++ b/GPS Logger/FlightLog.swift
@@ -35,6 +35,13 @@ struct FlightLog: Identifiable {
     let deltaCAS: Double?                  // kt
     let deltaHP: Double?                   // ft
 
+    /// 風向 (真方位) のログ。nil の場合は未記録。
+    let windDirection: Double?
+    /// 風速 (kt)。nil の場合は未記録。
+    let windSpeed: Double?
+    /// 風情報の入力ソース。"measured" または "manual" などを想定。
+    let windSource: String?
+
     // photo index (when capturing)
     let photoIndex: Int?
 }

--- a/GPS Logger/FlightLogManager.swift
+++ b/GPS Logger/FlightLogManager.swift
@@ -157,7 +157,10 @@ final class FlightLogManager: ObservableObject {
             Field(header: "theoreticalCAS(kt)", include: true) { "\($0.theoreticalCAS ?? 0)" },
             Field(header: "theoreticalHP(ft)", include: true) { "\($0.theoreticalHP ?? 0)" },
             Field(header: "deltaCAS(kt)", include: true) { "\($0.deltaCAS ?? 0)" },
-            Field(header: "deltaHP(ft)", include: true) { "\($0.deltaHP ?? 0)" }
+            Field(header: "deltaHP(ft)", include: true) { "\($0.deltaHP ?? 0)" },
+            Field(header: "windDirection", include: true) { "\($0.windDirection ?? 0)" },
+            Field(header: "windSpeed(kt)", include: true) { "\($0.windSpeed ?? 0)" },
+            Field(header: "windSource", include: true) { $0.windSource ?? "" }
         ]
 
         let activeFields = fields.filter { $0.include }

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -24,6 +24,11 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     var pendingPhotoIndex: Int? = nil
     var logTimer: Timer?
 
+    /// 手動または計測による風向・風速
+    @Published var windDirection: Double?
+    @Published var windSpeed: Double?
+    @Published var windSource: String?
+
     private var cancellables = Set<AnyCancellable>()
 
     init(flightLogManager: FlightLogManager,
@@ -161,7 +166,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                              theoreticalHP: nil,
                              deltaCAS: nil,
                              deltaHP: nil,
-                             photoIndex: pendingPhotoIndex)
+                             photoIndex: pendingPhotoIndex,
+                             windDirection: windDirection,
+                             windSpeed: windSpeed,
+                             windSource: windSource)
         pendingPhotoIndex = nil
         flightLogManager.addLog(log)
     }

--- a/GPS LoggerTests/GPS_LoggerTests.swift
+++ b/GPS LoggerTests/GPS_LoggerTests.swift
@@ -38,7 +38,10 @@ struct GPS_LoggerTests {
             baselineAltitude: nil,
             measuredAltitude: nil,
             kalmanUpdateInterval: nil,
-            photoIndex: nil)
+            photoIndex: nil,
+            windDirection: nil,
+            windSpeed: nil,
+            windSource: nil)
         manager.addLog(log)
 
         #expect(manager.flightLogs.count == 1)
@@ -78,7 +81,10 @@ struct GPS_LoggerTests {
             baselineAltitude: nil,
             measuredAltitude: nil,
             kalmanUpdateInterval: nil,
-            photoIndex: nil)
+            photoIndex: nil,
+            windDirection: nil,
+            windSpeed: nil,
+            windSource: nil)
         let log2 = FlightLog(
             timestamp: end,
             latitude: 35.001,
@@ -98,7 +104,10 @@ struct GPS_LoggerTests {
             baselineAltitude: nil,
             measuredAltitude: nil,
             kalmanUpdateInterval: nil,
-            photoIndex: nil)
+            photoIndex: nil,
+            windDirection: nil,
+            windSpeed: nil,
+            windSource: nil)
         manager.addLog(log1)
         manager.addLog(log2)
 


### PR DESCRIPTION
## Summary
- add wind data fields to `FlightLog`
- store wind info in logs and CSV export
- support manual wind input and TAS/OAT calc in main view
- refactor `FlightAssistView` to simple wind measurement UI

## Testing
- `swift test` *(fails: couldn't fetch swift-testing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_683bfdf0d0f0832681cafd55951f4cb5