### PR TITLE
Fix FlightLog argument order

### DIFF
--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -90,10 +90,10 @@ struct DistanceGraphView_Previews: PreviewProvider {
                 theoreticalHP: nil,
                 deltaCAS: nil,
                 deltaHP: nil,
-                photoIndex: nil,
                 windDirection: nil,
                 windSpeed: nil,
-                windSource: nil
+                windSource: nil,
+                photoIndex: nil
             )
         }
         NavigationStack {

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -166,10 +166,10 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                              theoreticalHP: nil,
                              deltaCAS: nil,
                              deltaHP: nil,
-                             photoIndex: pendingPhotoIndex,
                              windDirection: windDirection,
                              windSpeed: windSpeed,
-                             windSource: windSource)
+                             windSource: windSource,
+                             photoIndex: pendingPhotoIndex)
         pendingPhotoIndex = nil
         flightLogManager.addLog(log)
     }

--- a/GPS LoggerTests/GPS_LoggerTests.swift
+++ b/GPS LoggerTests/GPS_LoggerTests.swift
@@ -38,10 +38,10 @@ struct GPS_LoggerTests {
             baselineAltitude: nil,
             measuredAltitude: nil,
             kalmanUpdateInterval: nil,
-            photoIndex: nil,
             windDirection: nil,
             windSpeed: nil,
-            windSource: nil)
+            windSource: nil,
+            photoIndex: nil)
         manager.addLog(log)
 
         #expect(manager.flightLogs.count == 1)
@@ -81,10 +81,10 @@ struct GPS_LoggerTests {
             baselineAltitude: nil,
             measuredAltitude: nil,
             kalmanUpdateInterval: nil,
-            photoIndex: nil,
             windDirection: nil,
             windSpeed: nil,
-            windSource: nil)
+            windSource: nil,
+            photoIndex: nil)
         let log2 = FlightLog(
             timestamp: end,
             latitude: 35.001,
@@ -104,10 +104,10 @@ struct GPS_LoggerTests {
             baselineAltitude: nil,
             measuredAltitude: nil,
             kalmanUpdateInterval: nil,
-            photoIndex: nil,
             windDirection: nil,
             windSpeed: nil,
-            windSource: nil)
+            windSource: nil,
+            photoIndex: nil)
         manager.addLog(log1)
         manager.addLog(log2)
 


### PR DESCRIPTION
## Summary
- correct parameter order when initializing `FlightLog`
- adjust initializer usage in preview and tests

## Testing
- `swift test` *(fails: couldn't clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_683c000f2c4c8326b57cc66b0d2647d3