### PR TITLE
Improve wind measurement logic

### DIFF
--- a/GPS LoggerTests/LegRecorderTests.swift
+++ b/GPS LoggerTests/LegRecorderTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import GPS_Logger
+
+struct LegRecorderTests {
+    @Test
+    func testWindowFiltering() async throws {
+        var leg = FlightAssistView.LegRecorder(heading: 0)
+        let base = Date()
+        for i in 0..<10 {
+            leg.add(track: Double(i), speed: 100, at: base.addingTimeInterval(Double(i)))
+        }
+        if let summary = leg.summary(at: base.addingTimeInterval(10)) {
+            #expect(summary.duration <= 5.1 && summary.duration >= 4.9)
+            #expect(abs(summary.avgTrack - 7) < 0.1)
+        } else {
+            #expect(false, "summary was nil")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enhance FlightAssistView leg recorder logic with 5s window and auto stop
- vibrate and compute results after 3rd leg
- propagate measured wind to the main screen and compute TAS while altitude change within 500 ft
- add LegRecorder unit test

## Testing
- `swift test` *(fails: couldn't fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683c1258b57883269991b6af73ee429b