### PR TITLE
Change stable duration to 3 seconds

### DIFF
--- a/GPS Logger/FlightAssistView.swift
+++ b/GPS Logger/FlightAssistView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Flight Assist の表示とレグ管理を行うビュー。
 struct FlightAssistView: View {
+    static let stableDuration: TimeInterval = 3
     @EnvironmentObject var locationManager: LocationManager
     @Environment(\.dismiss) private var dismiss
 
@@ -9,7 +10,7 @@ struct FlightAssistView: View {
     struct LegRecorder {
         let heading: Int
         private(set) var samples: [(track: Double, speed: Double, time: Date)] = []
-        private let window: TimeInterval = 5
+        private let window: TimeInterval = FlightAssistView.stableDuration
 
         mutating func add(track: Double, speed: Double, at time: Date = Date()) {
             samples.append((track, speed, time))
@@ -58,7 +59,9 @@ struct FlightAssistView: View {
         let ciSpeed: Double
         let duration: TimeInterval
 
-        var isStable: Bool { duration >= 5 && ciTrack <= 3 && ciSpeed <= 3 }
+        var isStable: Bool {
+            duration >= FlightAssistView.stableDuration && ciTrack <= 3 && ciSpeed <= 3
+        }
     }
 
     // MARK: 状態
@@ -167,6 +170,11 @@ struct FlightAssistView: View {
                         Text(String(format: "GS %.1f ±%.1f kt", sum.avgSpeed, sum.ciSpeed))
                     }
                     .foregroundColor(sum.isStable ? .green : .primary)
+                    if !sum.isStable {
+                        Text(String(format: "安定まで %.1f 秒", max(0, FlightAssistView.stableDuration - sum.duration)))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
 

--- a/GPS LoggerTests/LegRecorderTests.swift
+++ b/GPS LoggerTests/LegRecorderTests.swift
@@ -10,8 +10,8 @@ struct LegRecorderTests {
             leg.add(track: Double(i), speed: 100, at: base.addingTimeInterval(Double(i)))
         }
         if let summary = leg.summary(at: base.addingTimeInterval(10)) {
-            #expect(summary.duration <= 5.1 && summary.duration >= 4.9)
-            #expect(abs(summary.avgTrack - 7) < 0.1)
+            #expect(summary.duration <= 3.1 && summary.duration >= 2.9)
+            #expect(abs(summary.avgTrack - 8) < 0.1)
         } else {
             #expect(false, "summary was nil")
         }


### PR DESCRIPTION
## Summary
- shorten the duration used to judge stability from 5s to 3s
- show remaining time until stable in FlightAssistView
- adjust LegRecorderTests for new duration

## Testing
- `swift test -q` *(fails: couldn't fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683c148b1f708326ae06b2c40d76ea37