### PR TITLE
Improve Flight Assist stability and logging

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -378,6 +378,7 @@ struct ContentView: View {
             .navigationDestination(isPresented: $showFlightAssist) {
                 FlightAssistView()
                     .environmentObject(locationManager)
+                    .environmentObject(settings)
             }
         }
     }

--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -93,6 +93,8 @@ struct DistanceGraphView_Previews: PreviewProvider {
                 windDirection: nil,
                 windSpeed: nil,
                 windSource: nil,
+                windDirectionCI: nil,
+                windSpeedCI: nil,
                 photoIndex: nil
             )
         }

--- a/GPS Logger/FlightAssistUtils.swift
+++ b/GPS Logger/FlightAssistUtils.swift
@@ -9,4 +9,30 @@ enum FlightAssistUtils {
         let tempK = (tasMps / mach) * (tasMps / mach) / (gamma * R)
         return tempK - 273.15
     }
+
+    /// 正規分布乱数を生成する。
+    static func randomNormal(mean: Double, sd: Double) -> Double {
+        let u1 = Double.random(in: 0..<1)
+        let u2 = Double.random(in: 0..<1)
+        let z0 = sqrt(-2.0 * log(u1)) * cos(2 * .pi * u2)
+        return z0 * sd + mean
+    }
+
+    /// 角度差を -180°...180° の範囲で返す。
+    static func angleDifferenceDeg(_ a: Double, _ b: Double) -> Double {
+        var diff = (a - b).truncatingRemainder(dividingBy: 360)
+        if diff > 180 { diff -= 360 }
+        if diff < -180 { diff += 360 }
+        return diff
+    }
+
+    /// 角度配列の循環平均を求める。
+    static func circularMeanDeg(_ values: [Double]) -> Double {
+        let sumSin = values.map { sin($0 * .pi / 180) }.reduce(0, +)
+        let sumCos = values.map { cos($0 * .pi / 180) }.reduce(0, +)
+        guard sumSin != 0 || sumCos != 0 else { return 0 }
+        var rad = atan2(sumSin, sumCos)
+        if rad < 0 { rad += 2 * .pi }
+        return rad * 180 / .pi
+    }
 }

--- a/GPS Logger/FlightLog.swift
+++ b/GPS Logger/FlightLog.swift
@@ -41,6 +41,10 @@ struct FlightLog: Identifiable {
     let windSpeed: Double?
     /// 風情報の入力ソース。"measured" または "manual" などを想定。
     let windSource: String?
+    /// 風向の95%信頼区間
+    let windDirectionCI: Double?
+    /// 風速の95%信頼区間
+    let windSpeedCI: Double?
 
     // photo index (when capturing)
     let photoIndex: Int?

--- a/GPS Logger/FlightLogManager.swift
+++ b/GPS Logger/FlightLogManager.swift
@@ -160,7 +160,9 @@ final class FlightLogManager: ObservableObject {
             Field(header: "deltaHP(ft)", include: true) { "\($0.deltaHP ?? 0)" },
             Field(header: "windDirection", include: true) { "\($0.windDirection ?? 0)" },
             Field(header: "windSpeed(kt)", include: true) { "\($0.windSpeed ?? 0)" },
-            Field(header: "windSource", include: true) { $0.windSource ?? "" }
+            Field(header: "windSource", include: true) { $0.windSource ?? "" },
+            Field(header: "windDirectionCI", include: true) { "\($0.windDirectionCI ?? 0)" },
+            Field(header: "windSpeedCI(kt)", include: true) { "\($0.windSpeedCI ?? 0)" }
         ]
 
         let activeFields = fields.filter { $0.include }

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -28,6 +28,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     @Published var windDirection: Double?
     @Published var windSpeed: Double?
     @Published var windSource: String?
+    @Published var windDirectionCI: Double?
+    @Published var windSpeedCI: Double?
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -169,6 +171,8 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                              windDirection: windDirection,
                              windSpeed: windSpeed,
                              windSource: windSource,
+                             windDirectionCI: windDirectionCI,
+                             windSpeedCI: windSpeedCI,
                              photoIndex: pendingPhotoIndex)
         pendingPhotoIndex = nil
         flightLogManager.addLog(log)

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -11,6 +11,11 @@ final class Settings: ObservableObject {
     @UserDefaultBacked(key: "logInterval") var logInterval: Double = 1.0
     @UserDefaultBacked(key: "baroWeight") var baroWeight: Double = 0.75
 
+    // Flight Assist stability thresholds
+    @UserDefaultBacked(key: "faStableDuration") var faStableDuration: Double = 3.0
+    @UserDefaultBacked(key: "faTrackCILimit") var faTrackCILimit: Double = 3.0
+    @UserDefaultBacked(key: "faSpeedCILimit") var faSpeedCILimit: Double = 3.0
+
     // Photo capture options
     @UserDefaultBacked(key: "photoPreSeconds") var photoPreSeconds: Double = 3.0
     @UserDefaultBacked(key: "photoPostSeconds") var photoPostSeconds: Double = 3.0
@@ -89,6 +94,18 @@ final class Settings: ObservableObject {
             .store(in: &cancellables)
 
         $recordKalmanInterval
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $faStableDuration
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $faTrackCILimit
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $faSpeedCILimit
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
     }

--- a/GPS Logger/SettingsView.swift
+++ b/GPS Logger/SettingsView.swift
@@ -54,6 +54,29 @@ struct SettingsView: View {
                 }
             }
 
+            Section(header: Text("Flight Assist")) {
+                HStack {
+                    Text("Stable Duration")
+                    Slider(value: $settings.faStableDuration, in: 1...10, step: 0.5)
+                    Text(String(format: "%.1f", settings.faStableDuration))
+                        .frame(width: 50, alignment: .trailing)
+                }
+
+                HStack {
+                    Text("Track CI Limit")
+                    Slider(value: $settings.faTrackCILimit, in: 1...10, step: 0.5)
+                    Text(String(format: "%.1f", settings.faTrackCILimit))
+                        .frame(width: 50, alignment: .trailing)
+                }
+
+                HStack {
+                    Text("Speed CI Limit")
+                    Slider(value: $settings.faSpeedCILimit, in: 1...10, step: 0.5)
+                    Text(String(format: "%.1f", settings.faSpeedCILimit))
+                        .frame(width: 50, alignment: .trailing)
+                }
+            }
+
             Section(header: Text("Recorded Fields")) {
                 Toggle("Record Acceleration", isOn: $settings.recordAcceleration)
                 Toggle("Record Altimeter Pressure", isOn: $settings.recordAltimeterPressure)

--- a/GPS LoggerTests/GPS_LoggerTests.swift
+++ b/GPS LoggerTests/GPS_LoggerTests.swift
@@ -41,6 +41,8 @@ struct GPS_LoggerTests {
             windDirection: nil,
             windSpeed: nil,
             windSource: nil,
+            windDirectionCI: nil,
+            windSpeedCI: nil,
             photoIndex: nil)
         manager.addLog(log)
 
@@ -84,6 +86,8 @@ struct GPS_LoggerTests {
             windDirection: nil,
             windSpeed: nil,
             windSource: nil,
+            windDirectionCI: nil,
+            windSpeedCI: nil,
             photoIndex: nil)
         let log2 = FlightLog(
             timestamp: end,
@@ -107,6 +111,8 @@ struct GPS_LoggerTests {
             windDirection: nil,
             windSpeed: nil,
             windSource: nil,
+            windDirectionCI: nil,
+            windSpeedCI: nil,
             photoIndex: nil)
         manager.addLog(log1)
         manager.addLog(log2)

--- a/GPS LoggerTests/LegRecorderTests.swift
+++ b/GPS LoggerTests/LegRecorderTests.swift
@@ -4,7 +4,7 @@ import Testing
 struct LegRecorderTests {
     @Test
     func testWindowFiltering() async throws {
-        var leg = FlightAssistView.LegRecorder(heading: 0)
+        var leg = FlightAssistView.LegRecorder(heading: 0, window: 3)
         let base = Date()
         for i in 0..<10 {
             leg.add(track: Double(i), speed: 100, at: base.addingTimeInterval(Double(i)))
@@ -12,6 +12,20 @@ struct LegRecorderTests {
         if let summary = leg.summary(at: base.addingTimeInterval(10)) {
             #expect(summary.duration <= 3.1 && summary.duration >= 2.9)
             #expect(abs(summary.avgTrack - 8) < 0.1)
+        } else {
+            #expect(false, "summary was nil")
+        }
+    }
+
+    @Test
+    func testCircularAverage() async throws {
+        var leg = FlightAssistView.LegRecorder(heading: 0, window: 3)
+        let base = Date()
+        leg.add(track: 350, speed: 100, at: base)
+        leg.add(track: 10, speed: 100, at: base.addingTimeInterval(1))
+        leg.add(track: 0, speed: 100, at: base.addingTimeInterval(2))
+        if let sum = leg.summary(at: base.addingTimeInterval(2.5)) {
+            #expect(abs(FlightAssistUtils.angleDifferenceDeg(sum.avgTrack, 0)) < 1)
         } else {
             #expect(false, "summary was nil")
         }


### PR DESCRIPTION
## Summary
- handle track angles using circular statistics
- allow stability thresholds to be configured in Settings
- compute and log 95% CI for wind results
- expose new parameters in Settings UI
- update tests for new LegRecorder API

## Testing
- `swift test -q` *(fails: Failed to clone repository)*

------
https://chatgpt.com/codex/tasks/task_e_683c197d5ed483268f70cc336f724537