### PR TITLE
UI tweaks and flight assist updates

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -106,8 +106,10 @@ struct ContentView: View {
                         }()
                         
                         VStack(alignment: .leading, spacing: 5) {
-                            Text("GPS受信時刻 (JST): \(loc.timestamp, formatter: DateFormatter.jstFormatter)")
-                            Text("緯度: \(loc.coordinate.latitude.toDegMin())  経度: \(loc.coordinate.longitude.toDegMin())").padding(.top, 4)
+                            if timeDiff > 3 {
+                                Text(String(format: "未受信 %.0f 秒", timeDiff))
+                                    .foregroundColor(.red)
+                            }
                             Text(String(format: "水平誤差: ±%.1f m", loc.horizontalAccuracy))
                             Text("磁方位: \(magneticText)").font(.title)
                             Text(String(format: "速度: %.1f kt", loc.speed * 1.94384)).font(.title)
@@ -136,6 +138,13 @@ struct ContentView: View {
                                 }
                                 if let tas = tas, let oat = oat {
                                     Text(String(format: "外気温: %.1f ℃", oat))
+                                    let cas = FlightAssistUtils.cas(tasKt: tas, altitudeFt: locationManager.rawGpsAltitude, oatC: oat)
+                                    let hp = FlightAssistUtils.pressureAltitude(altitudeFt: locationManager.rawGpsAltitude, oatC: oat)
+                                    Text(String(format: "CAS: %.1f kt", cas))
+                                    Text(String(format: "気圧高度: %.0f ft", hp))
+                                    locationManager.estimatedOAT = oat
+                                    locationManager.theoreticalCAS = cas
+                                    locationManager.theoreticalHP = hp
                                 }
                             } else {
                                 VStack(alignment: .leading, spacing: 8) {
@@ -368,6 +377,7 @@ struct ContentView: View {
             }
             .navigationDestination(isPresented: $showSettings) {
                 SettingsView(settings: settings)
+                    .environmentObject(locationManager)
             }
             .navigationDestination(isPresented: $showFlightAssist) {
                 FlightAssistView()

--- a/GPS Logger/FlightAssistUtils.swift
+++ b/GPS Logger/FlightAssistUtils.swift
@@ -35,4 +35,28 @@ enum FlightAssistUtils {
         if rad < 0 { rad += 2 * .pi }
         return rad * 180 / .pi
     }
+
+    /// TAS(kt)と高度(ft)から外気温度(℃)を求める
+    static func oat(tasKt: Double, altitudeFt: Double) -> Double {
+        let tasMps = tasKt * 0.514444
+        let tIsa = ISAAtmosphere.temperature(altitudeFt: altitudeFt) + 273.15
+        let speedOfSound = sqrt(1.4 * 287.05 * tIsa)
+        let mach = tasMps / speedOfSound
+        return oat(tasMps: tasMps, mach: mach)
+    }
+
+    /// TAS(kt)と高度(ft)、外気温度(℃)からCAS(kt)を概算する
+    static func cas(tasKt: Double, altitudeFt: Double, oatC: Double) -> Double {
+        let tasMps = tasKt * 0.514444
+        let pressure = ISAAtmosphere.pressure(altitudeFt: altitudeFt)
+        let density = pressure / (287.05 * (oatC + 273.15))
+        let eas = tasMps * sqrt(density / 1.225)
+        return eas / 0.514444
+    }
+
+    /// 外気温度に基づく気圧高度を概算する。ここでは簡易的に幾何高度を返す
+    static func pressureAltitude(altitudeFt: Double, oatC: Double) -> Double {
+        // 実際の圧力値が不明なため、暫定的にGPS高度をそのまま用いる
+        return altitudeFt
+    }
 }

--- a/GPS Logger/FlightAssistView.swift
+++ b/GPS Logger/FlightAssistView.swift
@@ -124,6 +124,13 @@ struct FlightAssistView: View {
             locationManager.windSource = "triangle"
             locationManager.windDirectionCI = windDirCI
             locationManager.windSpeedCI = windSpeedCI
+
+            let oat = FlightAssistUtils.oat(tasKt: result.tasKt, altitudeFt: locationManager.rawGpsAltitude)
+            let cas = FlightAssistUtils.cas(tasKt: result.tasKt, altitudeFt: locationManager.rawGpsAltitude, oatC: oat)
+            let hp = FlightAssistUtils.pressureAltitude(altitudeFt: locationManager.rawGpsAltitude, oatC: oat)
+            locationManager.estimatedOAT = oat
+            locationManager.theoreticalCAS = cas
+            locationManager.theoreticalHP = hp
         }
     }
 

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -31,6 +31,11 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     @Published var windDirectionCI: Double?
     @Published var windSpeedCI: Double?
 
+    /// 推算結果
+    @Published var estimatedOAT: Double?
+    @Published var theoreticalCAS: Double?
+    @Published var theoreticalHP: Double?
+
     private var cancellables = Set<AnyCancellable>()
 
     init(flightLogManager: FlightLogManager,
@@ -163,9 +168,9 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                              baselineAltitude: settings.recordBaselineAltitude ? altitudeFusionManager.baselineAltitude : nil,
                              measuredAltitude: settings.recordMeasuredAltitude ? altitudeFusionManager.measuredAltitude : nil,
                              kalmanUpdateInterval: settings.recordKalmanInterval ? altitudeFusionManager.kalmanUpdateInterval : nil,
-                             estimatedOAT: nil,
-                             theoreticalCAS: nil,
-                             theoreticalHP: nil,
+                             estimatedOAT: estimatedOAT,
+                             theoreticalCAS: theoreticalCAS,
+                             theoreticalHP: theoreticalHP,
                              deltaCAS: nil,
                              deltaHP: nil,
                              windDirection: windDirection,

--- a/GPS Logger/SettingsView.swift
+++ b/GPS Logger/SettingsView.swift
@@ -3,9 +3,19 @@ import SwiftUI
 /// A screen to adjust parameters used by altitude filtering and logging.
 struct SettingsView: View {
     @ObservedObject var settings: Settings
+    @EnvironmentObject var locationManager: LocationManager
 
     var body: some View {
         Form {
+            Section(header: Text("Current Location")) {
+                if let loc = locationManager.lastLocation {
+                    Text(String(format: "緯度: %.5f", loc.coordinate.latitude))
+                    Text(String(format: "経度: %.5f", loc.coordinate.longitude))
+                } else {
+                    Text("GPSデータ未取得")
+                }
+            }
+
             Section(header: Text("Kalman Filter")) {
                 HStack {
                     Text("Process Noise")
@@ -97,5 +107,8 @@ struct SettingsView: View {
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView(settings: Settings())
+            .environmentObject(LocationManager(flightLogManager: FlightLogManager(settings: Settings()),
+                                             altitudeFusionManager: AltitudeFusionManager(settings: Settings()),
+                                             settings: Settings()))
     }
 }


### PR DESCRIPTION
## Summary
- show GPS gap duration instead of timestamp
- compute OAT, CAS and HP when TAS is available
- move latitude/longitude info to Settings
- record new computed values in flight log

## Testing
- `swift build` *(fails: couldn't fetch swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_683c247bddc483269c145c2a34d5a5a2