### PR TITLE
Add GPS timestamp logging and bottom ribbon UI

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -194,86 +194,6 @@ struct ContentView: View {
                             .font(.title2)
                     }
                     
-                    if locationManager.isRecording {
-                        HStack(spacing: 40) {
-                            Button("記録停止") {
-                                locationManager.stopRecording()
-                                if let csvURL = flightLogManager.exportCSV() {
-                                    shareItems = [csvURL]
-                                    showingShareSheet = true
-                                }
-                                flightLogManager.endSession()
-                            }
-                            .font(.title2)
-                            .frame(width: 150, height: 60)
-                            .background(Color.red)
-                            .foregroundColor(.white)
-                            .cornerRadius(15)
-
-                            Button(measuringDistance ? "距離計測終了" : "距離計測開始") {
-                                if measuringDistance {
-                                    let now = Date()
-                                    if let result = flightLogManager.finishMeasurement(at: now) {
-                                        graphLogs = flightLogManager.flightLogs.filter { log in
-                                            log.timestamp >= result.startTime && log.timestamp <= result.endTime
-                                        }
-                                        measurementLogURL = flightLogManager.exportMeasurementLogs(for: result,
-                                                                                                 logs: graphLogs)
-
-                                        let graphView = DistanceGraphView(logs: graphLogs, measurement: result)
-                                        if let image = graphView.chartImage() {
-                                            measurementGraphURL = flightLogManager.exportMeasurementGraphImage(for: result,
-                                                                                                             chartImage: image)
-                                        } else {
-                                            measurementGraphURL = nil
-                                        }
-
-                                        lastMeasurement = result
-                                        showingDistanceGraph = true
-                                        measurementResultMessage = nil
-                                    } else {
-                                        measurementResultMessage = "計測に失敗しました"
-                                        showingMeasurementAlert = true
-                                        measurementLogURL = nil
-                                        measurementGraphURL = nil
-                                    }
-                                    measuringDistance = false
-                                    measurementStart = nil
-                                } else {
-                                    let start = Date()
-                                    measurementStart = start
-                                    flightLogManager.startMeasurement(at: start)
-                                    measuringDistance = true
-                                    measurementResultMessage = nil
-                                    measurementLogURL = nil
-                                    measurementGraphURL = nil
-                                }
-                            }
-                            .font(.title2)
-                            .frame(width: 160, height: 60)
-                            .background(measuringDistance ? Color.blue : Color.green)
-                            .foregroundColor(.white)
-                            .cornerRadius(15)
-
-                            Button("静止画撮影") {
-                                showingCompositeCamera = true
-                            }
-                            .font(.title2)
-                            .frame(width: 160, height: 60)
-                            .background(Color.orange)
-                            .foregroundColor(.white)
-                            .cornerRadius(15)
-                        }
-                    } else {
-                        Button("記録開始") {
-                            locationManager.startRecording()
-                        }
-                        .font(.title2)
-                        .frame(width: 150, height: 60)
-                        .background(Color.green)
-                        .foregroundColor(.white)
-                        .cornerRadius(15)
-                    }
                     
                     
                     if !flightLogManager.distanceMeasurements.isEmpty {
@@ -297,6 +217,7 @@ struct ContentView: View {
                     }
 
                     Spacer()
+                    buttonRibbon
                 }
                 .padding()
 
@@ -410,6 +331,87 @@ struct ContentView: View {
         let speedOfSound = sqrt(1.4 * 287.05 * tIsa)
         let mach = tasMps / speedOfSound
         return FlightAssistUtils.oat(tasMps: tasMps, mach: mach)
+    }
+
+    // Bottom ribbon containing action buttons
+    @ViewBuilder
+    var buttonRibbon: some View {
+        if locationManager.isRecording {
+            HStack(spacing: 20) {
+                Button("記録停止") {
+                    locationManager.stopRecording()
+                    if let csvURL = flightLogManager.exportCSV() {
+                        shareItems = [csvURL]
+                        showingShareSheet = true
+                    }
+                    flightLogManager.endSession()
+                }
+                .frame(width: 120, height: 50)
+                .background(Color.red)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+
+                Button(measuringDistance ? "距離計測終了" : "距離計測開始") {
+                    if measuringDistance {
+                        let now = Date()
+                        if let result = flightLogManager.finishMeasurement(at: now) {
+                            graphLogs = flightLogManager.flightLogs.filter { log in
+                                log.timestamp >= result.startTime && log.timestamp <= result.endTime
+                            }
+                            measurementLogURL = flightLogManager.exportMeasurementLogs(for: result,
+                                                                               logs: graphLogs)
+                            let graphView = DistanceGraphView(logs: graphLogs, measurement: result)
+                            if let image = graphView.chartImage() {
+                                measurementGraphURL = flightLogManager.exportMeasurementGraphImage(for: result,
+                                                                                                chartImage: image)
+                            } else {
+                                measurementGraphURL = nil
+                            }
+                            lastMeasurement = result
+                            showingDistanceGraph = true
+                            measurementResultMessage = nil
+                        } else {
+                            measurementResultMessage = "計測に失敗しました"
+                            showingMeasurementAlert = true
+                            measurementLogURL = nil
+                            measurementGraphURL = nil
+                        }
+                        measuringDistance = false
+                        measurementStart = nil
+                    } else {
+                        let start = Date()
+                        measurementStart = start
+                        flightLogManager.startMeasurement(at: start)
+                        measuringDistance = true
+                        measurementResultMessage = nil
+                        measurementLogURL = nil
+                        measurementGraphURL = nil
+                    }
+                }
+                .frame(width: 140, height: 50)
+                .background(measuringDistance ? Color.blue : Color.green)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+
+                Button("静止画撮影") {
+                    showingCompositeCamera = true
+                }
+                .frame(width: 120, height: 50)
+                .background(Color.orange)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+            }
+        } else {
+            HStack {
+                Button("記録開始") {
+                    locationManager.startRecording()
+                }
+                .frame(width: 150, height: 50)
+                .background(Color.green)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+            }
+        }
     }
 
 }

--- a/GPS Logger/DistanceGraphView.swift
+++ b/GPS Logger/DistanceGraphView.swift
@@ -68,6 +68,7 @@ struct DistanceGraphView_Previews: PreviewProvider {
 
             return FlightLog(
                 timestamp: timestamp,
+                gpsTimestamp: timestamp,
                 latitude: 0,
                 longitude: 0,
                 gpsAltitude: gpsAlt,

--- a/GPS Logger/FlightLog.swift
+++ b/GPS Logger/FlightLog.swift
@@ -4,6 +4,8 @@ import Foundation
 struct FlightLog: Identifiable {
     let id = UUID()
     let timestamp: Date
+    /// The timestamp provided by the GPS fix
+    let gpsTimestamp: Date
     let latitude: Double
     let longitude: Double
 

--- a/GPS Logger/FlightLogManager.swift
+++ b/GPS Logger/FlightLogManager.swift
@@ -131,6 +131,7 @@ final class FlightLogManager: ObservableObject {
 
         let fields: [Field] = [
             Field(header: "timestamp", include: true) { isoFormatter.string(from: $0.timestamp) },
+            Field(header: "gpsTimestamp", include: true) { isoFormatter.string(from: $0.gpsTimestamp) },
             Field(header: "latitude", include: true) { "\($0.latitude)" },
             Field(header: "longitude", include: true) { "\($0.longitude)" },
             Field(header: "gpsAltitude(ft)", include: true) { "\($0.gpsAltitude)" },

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -151,6 +151,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         let latestAcc = settings.recordAcceleration ? altitudeFusionManager.latestAcceleration : nil
 
         let log = FlightLog(timestamp: now,
+                             gpsTimestamp: loc.timestamp,
                              latitude: loc.coordinate.latitude,
                              longitude: loc.coordinate.longitude,
                              gpsAltitude: altitudeFt,

--- a/GPS LoggerTests/GPS_LoggerTests.swift
+++ b/GPS LoggerTests/GPS_LoggerTests.swift
@@ -21,6 +21,7 @@ struct GPS_LoggerTests {
         let now = Date()
         let log = FlightLog(
             timestamp: now,
+            gpsTimestamp: now,
             latitude: 35.0,
             longitude: 135.0,
             gpsAltitude: 1000,
@@ -66,6 +67,7 @@ struct GPS_LoggerTests {
 
         let log1 = FlightLog(
             timestamp: start,
+            gpsTimestamp: start,
             latitude: 35.0,
             longitude: 135.0,
             gpsAltitude: 0,
@@ -91,6 +93,7 @@ struct GPS_LoggerTests {
             photoIndex: nil)
         let log2 = FlightLog(
             timestamp: end,
+            gpsTimestamp: end,
             latitude: 35.001,
             longitude: 135.001,
             gpsAltitude: 100,


### PR DESCRIPTION
## Summary
- log GPS fix timestamp alongside regular timestamp
- include gpsTimestamp in CSV exports
- adapt unit tests for the new property
- move control buttons into a bottom ribbon for stable layout
- minor UI updates for clarity

## Testing
- `swift test` *(fails: couldn't clone swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_683c315ec8e88326b92a7e5f25044bac