### PR TITLE
Add manual pressure altitude input

### DIFF
--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -4,7 +4,7 @@ import UIKit
 import Combine
 
 /// Handles location updates and recording of log entries and photos.
-final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate, PressureAltitudeSource {
     private let locationManager = CLLocationManager()
 
     let flightLogManager: FlightLogManager
@@ -30,6 +30,9 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
     @Published var windSource: String?
     @Published var windDirectionCI: Double?
     @Published var windSpeedCI: Double?
+
+    /// 手動入力による気圧高度(ft)
+    @Published var pressureAltitudeFt: Double?
 
     /// 推算結果
     @Published var estimatedOAT: Double?
@@ -99,6 +102,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         rawGpsAltitude = 0.0
         rawGpsAltitudeChangeRate = 0.0
         previousRawAltitudeTimestamp = nil
+        pressureAltitudeFt = nil
 
         logTimer = Timer.scheduledTimer(withTimeInterval: settings.logInterval, repeats: true) { [weak self] _ in
             self?.recordLog()


### PR DESCRIPTION
## Summary
- allow manual pressure altitude input in ContentView
- store altitude value in LocationManager implementing `PressureAltitudeSource`
- reset manual value when recording starts
- warn user when GPS altitude differs by >2000ft from wind computation altitude

## Testing
- `swift test -q` *(fails: Failed to clone repository)*
- `swift build -c release -Xswiftc -warnings-as-errors` *(fails: Failed to clone repository)*


------
https://chatgpt.com/codex/tasks/task_e_683c382bb3508326a034ea13e06ebb98