### PR TITLE
Fix ambiguous toolbar call

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -245,7 +245,7 @@ struct ContentView: View {
             }
             .navigationTitle("GPS Logger")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
+            .toolbar(content: {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
                         showFlightAssist = true
@@ -260,7 +260,7 @@ struct ContentView: View {
                         Label("設定", systemImage: "gearshape")
                     }
                 }
-            }
+            })
             .onAppear {
                 UIApplication.shared.isIdleTimerDisabled = true
                 locationManager.startUpdatingForDisplay()
@@ -299,7 +299,7 @@ struct ContentView: View {
                 if let measurement = lastMeasurement {
                     NavigationStack {
                         DistanceGraphView(logs: graphLogs, measurement: measurement)
-                            .toolbar {
+                            .toolbar(content: {
                                 ToolbarItem(placement: .navigationBarTrailing) {
                                     if measurementLogURL != nil || measurementGraphURL != nil {
                                         Button {
@@ -316,7 +316,7 @@ struct ContentView: View {
                                         }
                                     }
                                 }
-                            }
+                            })
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- disambiguate toolbar modifier by specifying content label

## Testing
- `swift test` *(fails: Failed to clone repository)*

------
https://chatgpt.com/codex/tasks/task_e_683c4cec00048326b979a6e51653dfd5