### PR TITLE
Fix ambiguous toolbar usage

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -245,7 +245,7 @@ struct ContentView: View {
             }
             .navigationTitle("GPS Logger")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar(content: {
+            .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
                         showFlightAssist = true
@@ -260,7 +260,7 @@ struct ContentView: View {
                         Label("設定", systemImage: "gearshape")
                     }
                 }
-            })
+            }
             .onAppear {
                 UIApplication.shared.isIdleTimerDisabled = true
                 locationManager.startUpdatingForDisplay()
@@ -299,7 +299,7 @@ struct ContentView: View {
                 if let measurement = lastMeasurement {
                     NavigationStack {
                         DistanceGraphView(logs: graphLogs, measurement: measurement)
-                            .toolbar(content: {
+                            .toolbar {
                                 ToolbarItem(placement: .navigationBarTrailing) {
                                     if measurementLogURL != nil || measurementGraphURL != nil {
                                         Button {
@@ -316,7 +316,7 @@ struct ContentView: View {
                                         }
                                     }
                                 }
-                            })
+                            }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- resolve ambiguous `toolbar(content:)` usage in `ContentView`

## Testing
- `swift build` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_683c4e317d4c83269390da27642005ce