### PR TITLE
Fix ambiguous toolbar error

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -245,7 +245,7 @@ struct ContentView: View {
             }
             .navigationTitle("GPS Logger")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
+            .toolbar(role: .automatic, content: {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
                         showFlightAssist = true
@@ -260,7 +260,7 @@ struct ContentView: View {
                         Label("設定", systemImage: "gearshape")
                     }
                 }
-            }
+            })
             .onAppear {
                 UIApplication.shared.isIdleTimerDisabled = true
                 locationManager.startUpdatingForDisplay()
@@ -299,7 +299,7 @@ struct ContentView: View {
                 if let measurement = lastMeasurement {
                     NavigationStack {
                         DistanceGraphView(logs: graphLogs, measurement: measurement)
-                            .toolbar {
+                            .toolbar(role: .automatic, content: {
                                 ToolbarItem(placement: .navigationBarTrailing) {
                                     if measurementLogURL != nil || measurementGraphURL != nil {
                                         Button {
@@ -316,7 +316,7 @@ struct ContentView: View {
                                         }
                                     }
                                 }
-                            }
+                            })
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- disambiguate SwiftUI toolbar modifier by specifying `role: .automatic` parameter

## Testing
- `swift test` *(fails: unable to fetch swift-testing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_683c4fc9e3c083268b1bd87d3099b9cb