### PR TITLE
Display wind info in magnetic heading

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -118,7 +118,13 @@ struct ContentView: View {
                         }
                         let tas = within ? computeTAS(from: loc) : nil
                         let oat = tas.map { computeOAT(tasKt: $0, altitudeFt: locationManager.rawGpsAltitude) }
-                        Text(String(format: "風向 %.0f° 風速 %.1f kt (%@)", wd, ws, windSource ?? ""))
+                        let windMag: Double = {
+                            var mag = wd - locationManager.declination
+                            mag.formTruncatingRemainder(dividingBy: 360)
+                            if mag < 0 { mag += 360 }
+                            return mag
+                        }()
+                        Text(String(format: "風向 %.0f° 風速 %.1f kt (%@)", windMag, ws, windSource ?? ""))
                         if let tas = tas {
                             Text(String(format: "TAS: %.1f kt", tas))
                         }

--- a/GPS Logger/FlightAssistView.swift
+++ b/GPS Logger/FlightAssistView.swift
@@ -113,7 +113,11 @@ struct FlightAssistView: View {
         }
         if let result = TASTriangularSolver.solve(legs: legsForSolver) {
             tasResult = result.tasKt
-            windDirResult = result.windDirectionDeg
+            let windDirTrue = result.windDirectionDeg
+            var windDirMag = windDirTrue - locationManager.declination
+            windDirMag.formTruncatingRemainder(dividingBy: 360)
+            if windDirMag < 0 { windDirMag += 360 }
+            windDirResult = windDirMag
             windSpeedResult = result.windSpeedKt
             if let ci = windConfidenceIntervals(base: result) {
                 windDirCI = ci.0
@@ -122,7 +126,7 @@ struct FlightAssistView: View {
                 windDirCI = nil
                 windSpeedCI = nil
             }
-            locationManager.windDirection = windDirResult
+            locationManager.windDirection = windDirTrue
             locationManager.windSpeed = windSpeedResult
             locationManager.windSource = "triangle"
             locationManager.windDirectionCI = windDirCI
@@ -268,7 +272,10 @@ struct FlightAssistView: View {
                 }
                 Button("風入力保存") {
                     if let d = Double(manualWindDirection), let s = Double(manualWindSpeed) {
-                        locationManager.windDirection = d
+                        var dTrue = d + locationManager.declination
+                        dTrue.formTruncatingRemainder(dividingBy: 360)
+                        if dTrue < 0 { dTrue += 360 }
+                        locationManager.windDirection = dTrue
                         locationManager.windSpeed = s
                         locationManager.windSource = "manual"
                     }

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Kalman‑fused altitude and corresponding change rates for that measurement.
 
 These measurement logs make it easy to review altitude changes for a specific
 distance measurement alongside the overall flight log.
+
+## Wind Calculation Notes
+
+Aircraft heading inputs on the Flight Assist screen should be entered in
+**magnetic** degrees. The app automatically converts them to true heading using
+the device's current magnetic declination when performing wind calculations.
+Wind direction values shown in the UI are also displayed in magnetic degrees so
+that pilots can reference them directly. The underlying log records keep the
+true wind direction for later analysis.


### PR DESCRIPTION
## Summary
- convert wind direction to magnetic for display
- convert manually entered wind direction to true heading
- document heading requirements and wind display

## Testing
- `swift test` *(fails: couldn't clone swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_683dad9ca0548326b873ad042a9ead77