### PR TITLE
Implement OAT from CAS and pressure altitude

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -297,9 +297,12 @@ struct ContentView: View {
     }
 
     func computeOAT(tasKt: Double, altitudeFt: Double) -> Double {
+        if let hp = pressureAltitude, let cas = locationManager.theoreticalCAS {
+            return FlightAssistUtils.oat(tasKt: tasKt, casKt: cas, pressureAltitudeFt: hp)
+        }
+
         let tasMps = tasKt * 0.514444
 
-        // 手入力された気圧高度との差から外気温を推定する
         if let hp = pressureAltitude {
             // ISA 温度との差分 1℃ あたり約118.8 ft
             let tIsa = ISAAtmosphere.temperature(altitudeFt: altitudeFt)
@@ -308,10 +311,9 @@ struct ContentView: View {
 
             let speedOfSound = sqrt(1.4 * 287.05 * (oat + 273.15))
             let mach = tasMps / speedOfSound
-            _ = mach  // Mach は現在表示等に未使用だが計算しておく
+            _ = mach
             return oat
         } else {
-            // 気圧高度未入力時は従来手法で計算
             let tIsa = ISAAtmosphere.temperature(altitudeFt: altitudeFt) + 273.15
             let speedOfSound = sqrt(1.4 * 287.05 * tIsa)
             let mach = tasMps / speedOfSound

--- a/GPS Logger/FlightAssistUtils.swift
+++ b/GPS Logger/FlightAssistUtils.swift
@@ -59,4 +59,30 @@ enum FlightAssistUtils {
         // 実際の圧力値が不明なため、暫定的にGPS高度をそのまま用いる
         return altitudeFt
     }
+
+    /// TAS, CAS, 気圧高度から外気温度(℃)を求める
+    static func oat(tasKt: Double, casKt: Double, pressureAltitudeFt: Double) -> Double {
+        let tas = tasKt * 0.514444
+        let cas = casKt * 0.514444
+        let hp  = pressureAltitudeFt * 0.3048
+
+        let gamma = 1.4
+        let R     = 287.053
+        let g0    = 9.80665
+        let T0    = 288.15
+        let P0    = 101_325.0
+        let L     = 0.0065
+        let a0    = sqrt(gamma * R * T0)
+
+        let tIsa  = T0 - L * hp
+        let p     = P0 * pow(tIsa / T0, g0 / (R * L))
+        let delta = p / P0
+
+        let a2    = pow(cas / a0, 2)
+        let term  = pow(1 + a2 / 5, 3.5) - 1
+        let mach  = sqrt(5 * (pow(1 + term / delta, 2.0 / 7.0) - 1))
+
+        let tempK = tas * tas / (gamma * R * mach * mach)
+        return tempK - 273.15
+    }
 }

--- a/GPS LoggerTests/FlightAssistUtilsTests.swift
+++ b/GPS LoggerTests/FlightAssistUtilsTests.swift
@@ -7,4 +7,10 @@ struct FlightAssistUtilsTests {
         let oat = FlightAssistUtils.oat(tasMps: 250.0, mach: 0.8)
         #expect(oat > -60 && oat < 40)
     }
+
+    @Test
+    func testOATFromTASCAS() {
+        let oat = FlightAssistUtils.oat(tasKt: 194.4, casKt: 194.4, pressureAltitudeFt: 0)
+        #expect(abs(oat - 15.0) < 0.5)
+    }
 }


### PR DESCRIPTION
## Summary
- implement `FlightAssistUtils.oat(tasKt:casKt:pressureAltitudeFt:)` for computing OAT
- use the new function in `ContentView` when CAS and pressure altitude are available
- add unit test for the new OAT routine

## Testing
- `swift test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684382098cc48326a354c2db09c3acd1