### PR TITLE
Add map view and navigation services

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+import MapKit
+
+/// 空域データを管理し Map 上へ表示するためのマネージャ
+final class AirspaceManager: ObservableObject {
+    @Published private(set) var overlays: [MKPolyline] = []
+
+    /// GeoJSON ファイルから空域ラインを読み込む
+    func load(from url: URL) {
+        guard let data = try? Data(contentsOf: url) else { return }
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+        guard let features = obj["features"] as? [[String: Any]] else { return }
+
+        var loaded: [MKPolyline] = []
+        for feature in features {
+            guard let geometry = feature["geometry"] as? [String: Any],
+                  let type = geometry["type"] as? String,
+                  type == "LineString",
+                  let coords = geometry["coordinates"] as? [[Double]] else { continue }
+            let points = coords.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
+            let polyline = MKPolyline(coordinates: points, count: points.count)
+            loaded.append(polyline)
+        }
+        DispatchQueue.main.async {
+            self.overlays = loaded
+        }
+    }
+}

--- a/GPS Logger/GPS_LoggerApp.swift
+++ b/GPS Logger/GPS_LoggerApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct GPS_LoggerApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainMapView()
         }
     }
 }

--- a/GPS Logger/Map/MBTilesOverlay.swift
+++ b/GPS Logger/Map/MBTilesOverlay.swift
@@ -1,0 +1,57 @@
+import Foundation
+import MapKit
+import SQLite3
+
+/// MBTiles ファイルからタイル画像を読み込む MKTileOverlay の実装
+final class MBTilesOverlay: MKTileOverlay {
+    private let db: OpaquePointer?
+
+    init?(mbtilesURL: URL) {
+        var handle: OpaquePointer? = nil
+        if sqlite3_open_v2(mbtilesURL.path, &handle, SQLITE_OPEN_READONLY, nil) != SQLITE_OK {
+            return nil
+        }
+        self.db = handle
+        super.init(urlTemplate: nil)
+        tileSize = CGSize(width: 256, height: 256)
+        minimumZ = 1
+        maximumZ = 18
+    }
+
+    deinit {
+        if let handle = db {
+            sqlite3_close(handle)
+        }
+    }
+
+    override func loadTile(at path: MKTileOverlayPath, result: @escaping (Data?, Error?) -> Void) {
+        guard let handle = db else {
+            result(nil, NSError(domain: "MBTiles", code: 1))
+            return
+        }
+
+        let query = "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?"
+        var stmt: OpaquePointer? = nil
+        if sqlite3_prepare_v2(handle, query, -1, &stmt, nil) != SQLITE_OK {
+            result(nil, NSError(domain: "MBTiles", code: 2))
+            return
+        }
+        let row = Int(pow(2.0, Double(path.z))) - 1 - path.y
+        sqlite3_bind_int(stmt, 1, Int32(path.z))
+        sqlite3_bind_int(stmt, 2, Int32(path.x))
+        sqlite3_bind_int(stmt, 3, Int32(row))
+
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            if let bytes = sqlite3_column_blob(stmt, 0) {
+                let size = sqlite3_column_bytes(stmt, 0)
+                let data = Data(bytes: bytes, count: Int(size))
+                result(data, nil)
+            } else {
+                result(nil, NSError(domain: "MBTiles", code: 3))
+            }
+        } else {
+            result(nil, NSError(domain: "MBTiles", code: 4))
+        }
+        sqlite3_finalize(stmt)
+    }
+}

--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import MapKit
+
+/// Map 表示を行うメインビュー
+struct MainMapView: View {
+    @StateObject var settings = Settings()
+    @StateObject var flightLogManager = FlightLogManager(settings: Settings())
+    @StateObject var altitudeFusionManager = AltitudeFusionManager(settings: Settings())
+    @StateObject var locationManager: LocationManager
+    @StateObject var airspaceManager = AirspaceManager()
+
+    init() {
+        let settings = Settings()
+        _locationManager = StateObject(wrappedValue: LocationManager(flightLogManager: FlightLogManager(settings: settings), altitudeFusionManager: AltitudeFusionManager(settings: settings), settings: settings))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MapViewRepresentable(locationManager: locationManager, airspaceManager: airspaceManager)
+                    .ignoresSafeArea()
+            }
+            .navigationTitle("Map")
+            .toolbar {
+                NavigationLink("Detail") {
+                    ContentView(flightLogManager: flightLogManager, altitudeFusionManager: altitudeFusionManager, locationManager: locationManager)
+                }
+            }
+            .onAppear {
+                locationManager.startUpdatingForDisplay()
+            }
+        }
+    }
+}
+
+struct MapViewRepresentable: UIViewRepresentable {
+    let locationManager: LocationManager
+    let airspaceManager: AirspaceManager
+
+    func makeUIView(context: Context) -> MKMapView {
+        let map = MKMapView(frame: .zero)
+        map.showsUserLocation = true
+        map.delegate = context.coordinator
+        if let mbURL = Bundle.main.url(forResource: "basemap", withExtension: "mbtiles"),
+           let overlay = MBTilesOverlay(mbtilesURL: mbURL) {
+            map.addOverlay(overlay, level: .aboveLabels)
+        }
+        if let airURL = Bundle.main.url(forResource: "airspace", withExtension: "geojson") {
+            airspaceManager.load(from: airURL)
+        }
+        return map
+    }
+
+    func updateUIView(_ map: MKMapView, context: Context) {
+        let current = Set(map.overlays.compactMap { $0 as? MKPolyline })
+        let newSet = Set(airspaceManager.overlays)
+        if current != newSet {
+            map.removeOverlays(map.overlays)
+            if let mbURL = Bundle.main.url(forResource: "basemap", withExtension: "mbtiles"),
+               let overlay = MBTilesOverlay(mbtilesURL: mbURL) {
+                map.addOverlay(overlay, level: .aboveLabels)
+            }
+            map.addOverlays(Array(newSet))
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    class Coordinator: NSObject, MKMapViewDelegate {
+        func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let overlay = overlay as? MBTilesOverlay {
+                return MKTileOverlayRenderer(tileOverlay: overlay)
+            } else if let poly = overlay as? MKPolyline {
+                let renderer = MKPolylineRenderer(polyline: poly)
+                renderer.strokeColor = .red
+                renderer.lineWidth = 2
+                return renderer
+            }
+            return MKOverlayRenderer(overlay: overlay)
+        }
+    }
+}

--- a/GPS Logger/Navigation/NavCalcSvc.swift
+++ b/GPS Logger/Navigation/NavCalcSvc.swift
@@ -1,0 +1,76 @@
+import Foundation
+import CoreLocation
+import SQLite3
+
+/// Navaid データベースから地点を検索し、方位・距離計算を行うサービス
+final class NavCalcSvc {
+    private let db: OpaquePointer?
+
+    init?(dbURL: URL) {
+        var handle: OpaquePointer? = nil
+        if sqlite3_open_v2(dbURL.path, &handle, SQLITE_OPEN_READONLY, nil) != SQLITE_OK {
+            return nil
+        }
+        db = handle
+    }
+
+    deinit {
+        if let db { sqlite3_close(db) }
+    }
+
+    /// 指定した識別子の Navaid 座標を取得
+    func coordinate(for ident: String) -> CLLocationCoordinate2D? {
+        guard let db else { return nil }
+        let query = "SELECT lat, lon FROM navaids WHERE ident=? LIMIT 1"
+        var stmt: OpaquePointer? = nil
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        sqlite3_bind_text(stmt, 1, ident, -1, nil)
+        var coord: CLLocationCoordinate2D?
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            let lat = sqlite3_column_double(stmt, 0)
+            let lon = sqlite3_column_double(stmt, 1)
+            coord = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+        }
+        sqlite3_finalize(stmt)
+        return coord
+    }
+
+    /// 2 点間の距離(NM)と方位(磁方位)を計算
+    /// - Parameters:
+    ///   - from: 出発点座標
+    ///   - to: 目的点座標
+    ///   - declination: 磁気偏差 (度)。東偏は正、 西偏は負とする。
+    func bearingDistance(from: CLLocationCoordinate2D,
+                         to: CLLocationCoordinate2D,
+                         declination: Double = 0.0) -> (bearing: Double, distance: Double) {
+        let lat1 = from.latitude * Double.pi / 180
+        let lon1 = from.longitude * Double.pi / 180
+        let lat2 = to.latitude * Double.pi / 180
+        let lon2 = to.longitude * Double.pi / 180
+        let dLon = lon2 - lon1
+        let y = sin(dLon) * cos(lat2)
+        let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+        var bearing = atan2(y, x) * 180 / Double.pi
+        if bearing < 0 { bearing += 360 }
+        // 真方位から磁気偏差を引いて磁方位を得る
+        bearing -= declination
+        if bearing < 0 { bearing += 360 }
+        if bearing >= 360 { bearing -= 360 }
+        let r = 6371.0 // km
+        let d = acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(dLon)) * r
+        let nm = d / 1.852
+        return (bearing, nm)
+    }
+
+    /// 現在地と指定 Navaid との方位・距離を返す
+    /// - Parameters:
+    ///   - current: 現在地
+    ///   - ident: 対象 Navaid の識別子
+    ///   - declination: 磁気偏差 (度)
+    func info(from current: CLLocationCoordinate2D,
+              toIdent ident: String,
+              declination: Double = 0.0) -> (bearing: Double, distance: Double)? {
+        guard let dest = coordinate(for: ident) else { return nil }
+        return bearingDistance(from: current, to: dest, declination: declination)
+    }
+}

--- a/GPS LoggerTests/NavCalcSvcTests.swift
+++ b/GPS LoggerTests/NavCalcSvcTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import GPS_Logger
+import SQLite3
+
+struct NavCalcSvcTests {
+    @Test
+    func testBearingDistance() {
+        // 一時 SQLite データベースを生成
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("nav.db")
+        var db: OpaquePointer? = nil
+        sqlite3_open_v2(tmp.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        sqlite3_exec(db, "CREATE TABLE navaids (ident TEXT, lat REAL, lon REAL);", nil, nil, nil)
+        sqlite3_exec(db, "INSERT INTO navaids VALUES ('AAA', 35.0, 135.0);", nil, nil, nil)
+        sqlite3_close(db)
+
+        guard let svc = NavCalcSvc(dbURL: tmp) else {
+            #expect(false, "svc init failed")
+            return
+        }
+        let from = CLLocationCoordinate2D(latitude: 34.0, longitude: 134.0)
+        if let info = svc.info(from: from, toIdent: "AAA", declination: -7.0) {
+            #expect(info.distance > 70 && info.distance < 90)
+            #expect(info.bearing > 44 && info.bearing < 48)
+        } else {
+            #expect(false, "info nil")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement MBTiles overlay loader and AirspaceManager
- add NavCalcSvc for bearing/distance with SQLite database
- create MainMapView for offline map display and as main screen
- update app entry point to show MainMapView
- compute magnetic bearings in NavCalcSvc

## Testing
- `swift test` *(fails: unable to fetch swift-testing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6844c61359648326bbe71fe7dfad3239