### PR TITLE
Add initializer to ContentView for managers

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -255,6 +255,15 @@ struct ContentView: View {
         _locationManager = StateObject(wrappedValue: locationManager)
     }
 
+    init(flightLogManager: FlightLogManager,
+         altitudeFusionManager: AltitudeFusionManager,
+         locationManager: LocationManager) {
+        _settings = StateObject(wrappedValue: flightLogManager.settings)
+        _flightLogManager = StateObject(wrappedValue: flightLogManager)
+        _altitudeFusionManager = StateObject(wrappedValue: altitudeFusionManager)
+        _locationManager = StateObject(wrappedValue: locationManager)
+    }
+
 
     /// ナビゲーション周りをまとめたビュー
     private var navigationContent: some View {


### PR DESCRIPTION
## Summary
- add initializer to `ContentView` to accept existing managers so `MainMapView` can inject them

## Testing
- `swift test --enable-test-discovery` *(fails: unable to access https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc99f4a88326bc0d608a84c26c24