### PR TITLE
Add airspace overlay toggles

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -1,28 +1,83 @@
 import Foundation
+import Combine
 import MapKit
 
 /// 空域データを管理し Map 上へ表示するためのマネージャ
 final class AirspaceManager: ObservableObject {
-    @Published private(set) var overlays: [MKPolyline] = []
+    /// カテゴリごとに読み込んだオーバーレイを保持
+    @Published private(set) var overlaysByCategory: [String: [MKOverlay]] = [:]
+    /// 設定で有効化されているカテゴリ
+    private var enabledCategories: [String] { settings.enabledAirspaceCategories }
 
-    /// GeoJSON ファイルから空域ラインを読み込む
-    func load(from url: URL) {
-        guard let data = try? Data(contentsOf: url) else { return }
-        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-        guard let features = obj["features"] as? [[String: Any]] else { return }
+    /// 表示対象のオーバーレイ
+    @Published private(set) var displayOverlays: [MKOverlay] = []
 
-        var loaded: [MKPolyline] = []
+    /// 利用可能なカテゴリ一覧
+    var categories: [String] { overlaysByCategory.keys.sorted() }
+
+    private let settings: Settings
+    private var cancellables = Set<AnyCancellable>()
+
+    init(settings: Settings) {
+        self.settings = settings
+        settings.$enabledAirspaceCategories
+            .sink { [weak self] _ in self?.updateDisplayOverlays() }
+            .store(in: &cancellables)
+    }
+
+    /// バンドル内の Airspace フォルダからすべての GeoJSON を読み込む
+    func loadAll() {
+        guard let urls = Bundle.main.urls(forResourcesWithExtension: "geojson", subdirectory: "Airspace") else {
+            return
+        }
+
+        var map: [String: [MKOverlay]] = [:]
+        for url in urls {
+            let category = url.deletingPathExtension().lastPathComponent
+            map[category] = loadOverlays(from: url)
+        }
+        DispatchQueue.main.async { [self] in
+            overlaysByCategory = map
+            if settings.enabledAirspaceCategories.isEmpty {
+                settings.enabledAirspaceCategories = categories
+            }
+            updateDisplayOverlays()
+        }
+    }
+
+    /// 単一ファイルからオーバーレイを読み込む
+    private func loadOverlays(from url: URL) -> [MKOverlay] {
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let features = obj["features"] as? [[String: Any]] else { return [] }
+
+        var loaded: [MKOverlay] = []
         for feature in features {
             guard let geometry = feature["geometry"] as? [String: Any],
-                  let type = geometry["type"] as? String,
-                  type == "LineString",
-                  let coords = geometry["coordinates"] as? [[Double]] else { continue }
-            let points = coords.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
-            let polyline = MKPolyline(coordinates: points, count: points.count)
-            loaded.append(polyline)
+                  let type = geometry["type"] as? String else { continue }
+
+            switch type {
+            case "LineString":
+                if let coords = geometry["coordinates"] as? [[Double]] {
+                    let points = coords.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
+                    let polyline = MKPolyline(coordinates: points, count: points.count)
+                    loaded.append(polyline)
+                }
+            case "Polygon":
+                if let rings = geometry["coordinates"] as? [[[Double]]], let first = rings.first {
+                    let points = first.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
+                    let polygon = MKPolygon(coordinates: points, count: points.count)
+                    loaded.append(polygon)
+                }
+            default:
+                continue
+            }
         }
-        DispatchQueue.main.async {
-            self.overlays = loaded
-        }
+        return loaded
+    }
+
+    /// 表示対象オーバーレイを計算
+    private func updateDisplayOverlays() {
+        displayOverlays = enabledCategories.flatMap { overlaysByCategory[$0] ?? [] }
     }
 }

--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @StateObject var flightLogManager: FlightLogManager
     @StateObject var altitudeFusionManager: AltitudeFusionManager
     @StateObject var locationManager: LocationManager
+    @EnvironmentObject var airspaceManager: AirspaceManager
     
     @State private var currentTime = Date()
     @State private var capturedCompositeImage: UIImage?
@@ -535,6 +536,7 @@ private struct NavigationContentView: View {
             .navigationDestination(isPresented: $showSettings) {
                 SettingsView(settings: settings)
                     .environmentObject(locationManager)
+                    .environmentObject(airspaceManager)
             }
             .navigationDestination(isPresented: $showFlightAssist) {
                 FlightAssistView()

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -37,6 +37,9 @@ final class Settings: ObservableObject {
     @UserDefaultBacked(key: "showEllipsoidalAltitude") var showEllipsoidalAltitude: Bool = false
     @UserDefaultBacked(key: "recordEllipsoidalAltitude") var recordEllipsoidalAltitude: Bool = false
 
+    /// 表示する空域カテゴリ
+    @UserDefaultBacked(key: "enabledAirspaceCategories") var enabledAirspaceCategories: [String] = []
+
     // Mach/CAS calculation option
     @UserDefaultBacked(key: "enableMachCalculation") var enableMachCalculation: Bool = true
 
@@ -126,6 +129,10 @@ final class Settings: ObservableObject {
             .store(in: &cancellables)
 
         $recordEllipsoidalAltitude
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $enabledAirspaceCategories
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
 

--- a/GPS Logger/SettingsView.swift
+++ b/GPS Logger/SettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var settings: Settings
     @EnvironmentObject var locationManager: LocationManager
+    @EnvironmentObject var airspaceManager: AirspaceManager
 
     var body: some View {
         Form {
@@ -94,6 +95,25 @@ struct SettingsView: View {
             Section(header: Text("Display Options")) {
                 Toggle("楕円体高を表示", isOn: $settings.showEllipsoidalAltitude)
                 Toggle("Mach/CAS計算を有効化", isOn: $settings.enableMachCalculation)
+            }
+
+            if !airspaceManager.categories.isEmpty {
+                Section(header: Text("Airspace Layers")) {
+                    ForEach(airspaceManager.categories, id: \.self) { category in
+                        Toggle(category, isOn: Binding(
+                            get: { settings.enabledAirspaceCategories.contains(category) },
+                            set: { newValue in
+                                if newValue {
+                                    if !settings.enabledAirspaceCategories.contains(category) {
+                                        settings.enabledAirspaceCategories.append(category)
+                                    }
+                                } else {
+                                    settings.enabledAirspaceCategories.removeAll { $0 == category }
+                                }
+                            }
+                        ))
+                    }
+                }
             }
 
             Section(header: Text("Recorded Fields")) {


### PR DESCRIPTION
## Summary
- load all geojson files in `Airspace` folder and group by category
- store enabled airspace categories in `Settings`
- display map overlays according to the selected categories
- allow category toggles on the Settings screen
- share settings and airspace manager across views

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6844e86480d08326820813a91882664d