### PR TITLE
Fix airspaceManager injection

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -296,6 +296,7 @@ struct ContentView: View {
         .environmentObject(flightLogManager)
         .environmentObject(altitudeFusionManager)
         .environmentObject(locationManager)
+        .environmentObject(airspaceManager)
     }
 
     var body: some View {
@@ -452,6 +453,7 @@ private struct NavigationContentView: View {
     @EnvironmentObject var flightLogManager: FlightLogManager
     @EnvironmentObject var altitudeFusionManager: AltitudeFusionManager
     @EnvironmentObject var locationManager: LocationManager
+    @EnvironmentObject var airspaceManager: AirspaceManager
 
     @Binding var currentTime: Date
     @Binding var capturedCompositeImage: UIImage?


### PR DESCRIPTION
## Summary
- inject `airspaceManager` when constructing `NavigationContentView`
- declare `airspaceManager` as an environment object inside `NavigationContentView`

## Testing
- `swift test --enable-test-discovery` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844eddefe9083269223eb5347a4c24b