### PR TITLE
Add map layer settings view

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -8,6 +8,7 @@ struct MainMapView: View {
     @StateObject var altitudeFusionManager: AltitudeFusionManager
     @StateObject var locationManager: LocationManager
     @StateObject var airspaceManager: AirspaceManager
+    @State private var showLayerSettings = false
 
     init() {
         let settings = Settings()
@@ -36,7 +37,19 @@ struct MainMapView: View {
                     )
                     .environmentObject(airspaceManager)
                 }
+                Button {
+                    showLayerSettings = true
+                } label: {
+                    Label("レイヤ", systemImage: "square.3.stack.3d")
+                }
             })
+            .sheet(isPresented: $showLayerSettings) {
+                NavigationStack {
+                    MapLayerSettingsView()
+                        .environmentObject(settings)
+                        .environmentObject(airspaceManager)
+                }
+            }
             .onAppear {
                 locationManager.startUpdatingForDisplay()
             }

--- a/GPS Logger/Map/MapLayerSettingsView.swift
+++ b/GPS Logger/Map/MapLayerSettingsView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// 空域レイヤの表示設定を行う画面
+struct MapLayerSettingsView: View {
+    @EnvironmentObject var settings: Settings
+    @EnvironmentObject var airspaceManager: AirspaceManager
+
+    var body: some View {
+        Form {
+            if !airspaceManager.categories.isEmpty {
+                Section(header: Text("空域レイヤ")) {
+                    ForEach(airspaceManager.categories, id: \.self) { category in
+                        Toggle(category, isOn: Binding(
+                            get: { settings.enabledAirspaceCategories.contains(category) },
+                            set: { newValue in
+                                if newValue {
+                                    if !settings.enabledAirspaceCategories.contains(category) {
+                                        settings.enabledAirspaceCategories.append(category)
+                                    }
+                                } else {
+                                    settings.enabledAirspaceCategories.removeAll { $0 == category }
+                                }
+                            }
+                        ))
+                    }
+                }
+            }
+        }
+        .navigationTitle("レイヤ設定")
+    }
+}
+
+# Preview
+struct MapLayerSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        MapLayerSettingsView()
+            .environmentObject(Settings())
+            .environmentObject(AirspaceManager(settings: Settings()))
+    }
+}

--- a/GPS Logger/SettingsView.swift
+++ b/GPS Logger/SettingsView.swift
@@ -97,24 +97,6 @@ struct SettingsView: View {
                 Toggle("Mach/CAS計算を有効化", isOn: $settings.enableMachCalculation)
             }
 
-            if !airspaceManager.categories.isEmpty {
-                Section(header: Text("Airspace Layers")) {
-                    ForEach(airspaceManager.categories, id: \.self) { category in
-                        Toggle(category, isOn: Binding(
-                            get: { settings.enabledAirspaceCategories.contains(category) },
-                            set: { newValue in
-                                if newValue {
-                                    if !settings.enabledAirspaceCategories.contains(category) {
-                                        settings.enabledAirspaceCategories.append(category)
-                                    }
-                                } else {
-                                    settings.enabledAirspaceCategories.removeAll { $0 == category }
-                                }
-                            }
-                        ))
-                    }
-                }
-            }
 
             Section(header: Text("Recorded Fields")) {
                 Toggle("Record Acceleration", isOn: $settings.recordAcceleration)

--- a/GPS LoggerUITests/GPS_LoggerUITests.swift
+++ b/GPS LoggerUITests/GPS_LoggerUITests.swift
@@ -46,6 +46,20 @@ final class GPS_LoggerUITests: XCTestCase {
         stopButton.tap()
     }
 
+    /// 地図画面からレイヤ設定画面へ遷移できることを検証
+    @MainActor
+    func testOpenLayerSettings() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        let layersButton = app.buttons["レイヤ"]
+        XCTAssertTrue(layersButton.waitForExistence(timeout: 2))
+        layersButton.tap()
+
+        let navBar = app.navigationBars["レイヤ設定"]
+        XCTAssertTrue(navBar.waitForExistence(timeout: 2))
+    }
+
     @MainActor
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {


### PR DESCRIPTION
## Summary
- cut airspace layer toggles out of `SettingsView`
- create new `MapLayerSettingsView` for choosing layers
- show map layer settings from `MainMapView` via a new toolbar button
- pass `Settings` and `AirspaceManager` as environment objects
- add UI test verifying layer settings screen opens

## Testing
- `swift test -v` *(fails: unable to clone dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6844f0d747cc8326beedcc065e8e97eb