### PR TITLE
Load airspace in background

### DIFF
--- a/GPS LoggerTests/AirspaceManagerAsyncTests.swift
+++ b/GPS LoggerTests/AirspaceManagerAsyncTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import GPS_Logger
+
+final class AirspaceManagerAsyncTests: XCTestCase {
+    /// 大きめの GeoJSON ファイルを生成
+    private func makeLargeGeoJSON() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent("large.geojson")
+        var features: [String] = []
+        for i in 0..<200 {
+            var points: [String] = []
+            for j in 0..<50 {
+                let lat = Double(i) * 0.001 + Double(j) * 0.0001
+                let lon = Double(i) * 0.001 + Double(j) * 0.0001
+                points.append("[\(lon),\(lat)]")
+            }
+            let line = "{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[" + points.joined(separator: ",") + "]}}"
+            features.append(line)
+        }
+        let json = "{\"type\":\"FeatureCollection\",\"features\":[" + features.joined(separator: ",") + "]}"
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    func testBackgroundLoadDoesNotBlockMain() throws {
+        let fileURL = try makeLargeGeoJSON()
+        let settings = Settings()
+        let manager = AirspaceManager(settings: settings)
+
+        // 呼び出しが即座に返ることを確認
+        let start = CFAbsoluteTimeGetCurrent()
+        manager.loadAll(urls: [fileURL])
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        XCTAssertLessThan(elapsed, 0.1)
+
+        // 読み込み完了を待つ
+        let exp = expectation(description: "load")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            if !manager.displayOverlays.isEmpty {
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 5.0)
+    }
+}


### PR DESCRIPTION
## Summary
- load geojson in the background via `DispatchQueue.global`
- update overlays on the main thread
- expose optional `urls` argument for testing
- add async unit test verifying the load call doesn't block

## Testing
- `swift test --enable-test-discovery` *(fails: unable to clone dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6844f35d67f4832690d04bad9d67c652