### PR TITLE
Add AirspaceManager display overlay tests

### DIFF
--- a/GPS LoggerTests/AirspaceManagerTests.swift
+++ b/GPS LoggerTests/AirspaceManagerTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import GPS_Logger
+
+final class AirspaceManagerTests: XCTestCase {
+    /// テスト用 GeoJSON ファイル URL を取得
+    private func testFileURLs() throws -> [URL] {
+        guard let a = Bundle.module.url(forResource: "catA", withExtension: "geojson"),
+              let b = Bundle.module.url(forResource: "catB", withExtension: "geojson") else {
+            throw XCTSkip("Test files not found")
+        }
+        return [a, b]
+    }
+
+    func testLoadAndFilter() throws {
+        let urls = try testFileURLs()
+        let settings = Settings()
+        let manager = AirspaceManager(settings: settings)
+
+        let exp = expectation(description: "load")
+        manager.loadAll(urls: urls)
+        // 読み込みが完了し displayOverlays が更新されるまで待つ
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            if manager.displayOverlays.count == 2 {
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 2.0)
+
+        XCTAssertEqual(manager.displayOverlays.count, 2)
+        XCTAssertEqual(Set(settings.enabledAirspaceCategories), Set(["catA", "catB"]))
+
+        // カテゴリを片方だけ有効に
+        settings.enabledAirspaceCategories = ["catA"]
+        XCTAssertEqual(manager.displayOverlays.count, 1)
+
+        settings.enabledAirspaceCategories = ["catB"]
+        XCTAssertEqual(manager.displayOverlays.count, 1)
+    }
+}

--- a/GPS LoggerTests/TestData/catA.geojson
+++ b/GPS LoggerTests/TestData/catA.geojson
@@ -1,0 +1,15 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [0.0, 0.0],
+          [0.1, 0.1]
+        ]
+      }
+    }
+  ]
+}

--- a/GPS LoggerTests/TestData/catB.geojson
+++ b/GPS LoggerTests/TestData/catB.geojson
@@ -1,0 +1,19 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [0.0, 0.0],
+            [0.0, 0.1],
+            [0.1, 0.0],
+            [0.0, 0.0]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
                 "GPS_Logger",
                 .product(name: "Testing", package: "swift-testing")
             ],
-            path: "GPS LoggerTests"
+            path: "GPS LoggerTests",
+            resources: [
+                .process("TestData")
+            ]
         )
         // UI tests are not included in SPM
     ]


### PR DESCRIPTION
## Summary
- add tiny GeoJSON files for tests
- add AirspaceManagerTests for loading and category filtering
- update Package.swift to process test resources

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844f492a8fc8326b1de71ee8a3815da