### PR TITLE
Fix Bundle.module for non-SPM builds

### DIFF
--- a/GPS Logger/Bundle+Module.swift
+++ b/GPS Logger/Bundle+Module.swift
@@ -1,0 +1,10 @@
+#if !SWIFT_PACKAGE
+import Foundation
+
+extension Bundle {
+    /// Swift Package Manager 環境以外で `Bundle.module` を利用できるようにする
+    static var module: Bundle {
+        Bundle.main
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add fallback extension for `Bundle.module` so Xcode project builds

## Testing
- `swift test` *(fails: unable to access https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6844f9adcab08326a42c8378abb1577b