### PR TITLE
Fix OAT calculation edge case

### DIFF
--- a/GPS Logger/FlightAssistUtils.swift
+++ b/GPS Logger/FlightAssistUtils.swift
@@ -4,6 +4,8 @@ import Foundation
 enum FlightAssistUtils {
     /// TAS とマッハ数から外気温度 (℃) を求める。
     static func oat(tasMps: Double, mach: Double) -> Double {
+        guard mach > 0 else { return 0 }
+
         let gamma = 1.4
         let R = 287.0
         let tempK = (tasMps / mach) * (tasMps / mach) / (gamma * R)

--- a/GPS LoggerTests/FlightAssistUtilsTests.swift
+++ b/GPS LoggerTests/FlightAssistUtilsTests.swift
@@ -13,4 +13,10 @@ struct FlightAssistUtilsTests {
         let oat = FlightAssistUtils.oat(tasKt: 194.4, casKt: 194.4, pressureAltitudeFt: 0)
         #expect(abs(oat - 15.0) < 0.5)
     }
+
+    @Test
+    func testOATZeroMach() {
+        let oat = FlightAssistUtils.oat(tasMps: 100.0, mach: 0.0)
+        #expect(oat == 0)
+    }
 }


### PR DESCRIPTION
## Summary
- avoid division by zero in `FlightAssistUtils.oat`
- add regression test for zero Mach

## Testing
- `swift test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844fd5e0dcc832686797e7182b2dc36