### PR TITLE
Add vector MBTiles support for airspace

### DIFF
--- a/GPS Logger/Airspace/MBTilesVectorSource.swift
+++ b/GPS Logger/Airspace/MBTilesVectorSource.swift
@@ -1,0 +1,100 @@
+import Foundation
+import MapKit
+import SQLite3
+
+/// MBTiles 形式で保存されたベクターデータを読み込み、表示領域に応じてオーバーレイを生成するクラス
+final class MBTilesVectorSource {
+    private let db: OpaquePointer?
+    private let zoomLevel: Int
+    private struct TileIndex: Hashable { let x: Int; let y: Int; let z: Int }
+    private var cache: [TileIndex: [MKOverlay]] = [:]
+
+    init?(url: URL, zoomLevel: Int = 8) {
+        var handle: OpaquePointer? = nil
+        if sqlite3_open_v2(url.path, &handle, SQLITE_OPEN_READONLY, nil) != SQLITE_OK {
+            return nil
+        }
+        self.db = handle
+        self.zoomLevel = zoomLevel
+    }
+
+    deinit {
+        if let handle = db {
+            sqlite3_close(handle)
+        }
+    }
+
+    /// 指定した MapRect 内に含まれるタイルのオーバーレイを返す
+    func overlays(in mapRect: MKMapRect) -> [MKOverlay] {
+        let nw = MKMapPoint(x: mapRect.minX, y: mapRect.minY).coordinate
+        let se = MKMapPoint(x: mapRect.maxX, y: mapRect.maxY).coordinate
+        let (minX, minY) = tileXY(for: nw)
+        let (maxX, maxY) = tileXY(for: se)
+        var result: [MKOverlay] = []
+        for x in minX...maxX {
+            for y in minY...maxY {
+                let idx = TileIndex(x: x, y: y, z: zoomLevel)
+                if let cached = cache[idx] {
+                    result.append(contentsOf: cached)
+                } else if let overlays = loadTile(x: x, y: y, z: zoomLevel) {
+                    cache[idx] = overlays
+                    result.append(contentsOf: overlays)
+                }
+            }
+        }
+        return result
+    }
+
+    private func tileXY(for coord: CLLocationCoordinate2D) -> (Int, Int) {
+        let n = pow(2.0, Double(zoomLevel))
+        let x = Int((coord.longitude + 180.0) / 360.0 * n)
+        let latRad = coord.latitude * Double.pi / 180.0
+        let y = Int((1.0 - log(tan(latRad) + 1.0 / cos(latRad)) / Double.pi) / 2.0 * n)
+        return (max(0, min(Int(n) - 1, x)), max(0, min(Int(n) - 1, y)))
+    }
+
+    private func loadTile(x: Int, y: Int, z: Int) -> [MKOverlay]? {
+        guard let handle = db else { return nil }
+        let row = Int(pow(2.0, Double(z))) - 1 - y
+        let query = "SELECT tile_data FROM tiles WHERE zoom_level=? AND tile_column=? AND tile_row=?"
+        var stmt: OpaquePointer? = nil
+        if sqlite3_prepare_v2(handle, query, -1, &stmt, nil) != SQLITE_OK { return nil }
+        sqlite3_bind_int(stmt, 1, Int32(z))
+        sqlite3_bind_int(stmt, 2, Int32(x))
+        sqlite3_bind_int(stmt, 3, Int32(row))
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        if let bytes = sqlite3_column_blob(stmt, 0) {
+            let size = sqlite3_column_bytes(stmt, 0)
+            let data = Data(bytes: bytes, count: Int(size))
+            return parseTileData(data)
+        }
+        return nil
+    }
+
+    /// tile_data は GeoJSON の FeatureCollection を想定
+    private func parseTileData(_ data: Data) -> [MKOverlay]? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let features = obj["features"] as? [[String: Any]] else { return nil }
+        var overlays: [MKOverlay] = []
+        for feat in features {
+            guard let geom = feat["geometry"] as? [String: Any],
+                  let type = geom["type"] as? String else { continue }
+            switch type {
+            case "LineString":
+                if let coords = geom["coordinates"] as? [[Double]] {
+                    let points = coords.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
+                    overlays.append(MKPolyline(coordinates: points, count: points.count))
+                }
+            case "Polygon":
+                if let rings = geom["coordinates"] as? [[[Double]]], let first = rings.first {
+                    let points = first.map { CLLocationCoordinate2D(latitude: $0[1], longitude: $0[0]) }
+                    overlays.append(MKPolygon(coordinates: points, count: points.count))
+                }
+            default:
+                continue
+            }
+        }
+        return overlays
+    }
+}

--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -81,14 +81,20 @@ struct MapViewRepresentable: UIViewRepresentable {
         let current = map.overlays.filter { !($0 is MBTilesOverlay) }
         map.removeOverlays(current)
         map.addOverlays(airspaceManager.displayOverlays)
+        airspaceManager.updateMapRect(map.visibleMapRect)
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(airspaceManager: airspaceManager)
     }
 
     class Coordinator: NSObject, MKMapViewDelegate {
         private var infoAnnotation: MKPointAnnotation?
+        private let airspaceManager: AirspaceManager
+
+        init(airspaceManager: AirspaceManager) {
+            self.airspaceManager = airspaceManager
+        }
 
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
             if let overlay = overlay as? MBTilesOverlay {
@@ -137,6 +143,10 @@ struct MapViewRepresentable: UIViewRepresentable {
             let view = mapView.dequeueReusableAnnotationView(withIdentifier: id) ?? MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: id)
             view.canShowCallout = true
             return view
+        }
+
+        func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+            airspaceManager.updateMapRect(mapView.visibleMapRect)
         }
     }
 }

--- a/GPS LoggerTests/AirspaceVectorTilesTests.swift
+++ b/GPS LoggerTests/AirspaceVectorTilesTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import GPS_Logger
+
+final class AirspaceVectorTilesTests: XCTestCase {
+    private func makeMBTiles() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("vec.mbtiles")
+        var db: OpaquePointer? = nil
+        sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        defer { if let db = db { sqlite3_close(db) } }
+        sqlite3_exec(db, "CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);", nil, nil, nil)
+        let json = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[0,0.1],[0.1,0],[0,0]]]}]}]" // purposely simple
+        var stmt: OpaquePointer? = nil
+        sqlite3_prepare_v2(db, "INSERT INTO tiles VALUES (0,0,0,?)", -1, &stmt, nil)
+        sqlite3_bind_blob(stmt, 1, json, Int32(json.utf8.count), nil)
+        sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        return url
+    }
+
+    func testManagerLoadsVectorTiles() throws {
+        let tileURL = try makeMBTiles()
+        let settings = Settings()
+        let manager = AirspaceManager(settings: settings)
+        manager.loadAll(urls: [tileURL])
+
+        let exp = expectation(description: "load")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            manager.updateMapRect(.world)
+            if manager.displayOverlays.count == 1 {
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(manager.displayOverlays.count, 1)
+    }
+}

--- a/GPS LoggerTests/MBTilesVectorSourceTests.swift
+++ b/GPS LoggerTests/MBTilesVectorSourceTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import GPS_Logger
+import SQLite3
+
+final class MBTilesVectorSourceTests: XCTestCase {
+    /// 簡易的な MBTiles ファイルを生成
+    private func makeMBTiles() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test.mbtiles")
+        var db: OpaquePointer? = nil
+        sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        defer { if let db = db { sqlite3_close(db) } }
+        sqlite3_exec(db, "CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);", nil, nil, nil)
+        let json = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[0,0],[0.1,0.1]]}}]}"
+        var stmt: OpaquePointer? = nil
+        sqlite3_prepare_v2(db, "INSERT INTO tiles VALUES (0,0,0,?)", -1, &stmt, nil)
+        sqlite3_bind_blob(stmt, 1, json, Int32(json.utf8.count), nil)
+        sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        return url
+    }
+
+    func testLoadTile() throws {
+        let url = try makeMBTiles()
+        guard let src = MBTilesVectorSource(url: url) else {
+            XCTFail("failed to open mbtiles")
+            return
+        }
+        let overlays = src.overlays(in: MKMapRect.world)
+        XCTAssertEqual(overlays.count, 1)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Flight Assist 画面では、計測値を検証するためにグランドトラ
 
 ## Map Overlays
 
-The app displays a basemap from an MBTiles file and optional airspace overlays from GeoJSON files. GeoJSON files placed in the `Airspace` directory are loaded when the map view is created. Each file is treated as a category identified by its filename without the extension. The contents of every file are parsed on a background thread and converted to `MKPolyline` or `MKPolygon` objects depending on the geometry type.
+The app displays a basemap from an MBTiles file and optional airspace overlays from GeoJSON or vector MBTiles files. Data placed in the `Airspace` directory is loaded when the map view is created. Each file is treated as a category identified by its filename without the extension. GeoJSON files are parsed on a background thread and converted to `MKPolyline` or `MKPolygon` objects. Vector MBTiles are read tile by tile so only features within the current map view are loaded.
 
 When you open the map screen, tap the stack icon in the toolbar to show the layer settings. A list of categories appears and you can toggle each overlay on or off. The map refreshes immediately to reflect your choices.
 
-Only `LineString` and `Polygon` features are supported. Multi‑geometry types are ignored. To add new data, bundle additional GeoJSON files in the `Airspace` folder.
+Only `LineString` and `Polygon` features are supported. Multi‑geometry types are ignored. To add new data, bundle additional GeoJSON or vector MBTiles files in the `Airspace` folder.


### PR DESCRIPTION
## Summary
- manage vector airspace data using `MBTilesVectorSource`
- update `AirspaceManager` to load GeoJSON or MBTiles and filter by visible map region
- refresh overlays in `MainMapView` as the map region changes
- document vector tile support
- add unit tests for MBTiles vector sources

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6845143781e083268663575c6a376494