### PR TITLE
Fix high CPU usage on map load

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -74,6 +74,7 @@ struct MapViewRepresentable: UIViewRepresentable {
            let overlay = MBTilesOverlay(mbtilesURL: mbURL) {
             map.addOverlay(overlay, level: .aboveLabels)
         }
+        airspaceManager.updateMapRect(map.visibleMapRect)
         return map
     }
 
@@ -81,7 +82,6 @@ struct MapViewRepresentable: UIViewRepresentable {
         let current = map.overlays.filter { !($0 is MBTilesOverlay) }
         map.removeOverlays(current)
         map.addOverlays(airspaceManager.displayOverlays)
-        airspaceManager.updateMapRect(map.visibleMapRect)
     }
 
     func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
## Summary
- avoid recursive update loop in MapViewRepresentable
- set initial map region once during makeUIView

## Testing
- `swift test -v` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68451bdcb8b0832680034caecf3b48b3