### PR TITLE
Set initial map region to 40NM

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -82,6 +82,16 @@ struct MapViewRepresentable: UIViewRepresentable {
         let current = map.overlays.filter { !($0 is MBTilesOverlay) }
         map.removeOverlays(current)
         map.addOverlays(airspaceManager.displayOverlays)
+
+        if !context.coordinator.regionSet,
+           let loc = locationManager.lastLocation {
+            let meters = 40.0 * 1852.0
+            let region = MKCoordinateRegion(center: loc.coordinate,
+                                            latitudinalMeters: meters,
+                                            longitudinalMeters: meters)
+            map.setRegion(region, animated: false)
+            context.coordinator.regionSet = true
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -91,6 +101,7 @@ struct MapViewRepresentable: UIViewRepresentable {
     class Coordinator: NSObject, MKMapViewDelegate {
         private var infoAnnotation: MKPointAnnotation?
         private let airspaceManager: AirspaceManager
+        var regionSet = false
 
         init(airspaceManager: AirspaceManager) {
             self.airspaceManager = airspaceManager


### PR DESCRIPTION
## Summary
- make the map view zoom to 40NM around user location when first displayed

## Testing
- `swift test --enable-code-coverage` *(fails: unable to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_68451d6409e883268b30b3417c6a0983