### PR TITLE
Add PBF vector tile support

### DIFF
--- a/GPS Logger/Airspace/VectorTileParser.swift
+++ b/GPS Logger/Airspace/VectorTileParser.swift
@@ -1,0 +1,203 @@
+import Foundation
+import MapKit
+import Compression
+
+/// Mapbox Vector Tile を簡易的に解析するパーサ
+struct VectorTileParser {
+    struct Feature {
+        enum GeometryType: Int {
+            case unknown = 0
+            case point = 1
+            case lineString = 2
+            case polygon = 3
+        }
+        let type: GeometryType
+        let geometry: [[(Int, Int)]]
+    }
+
+    struct Layer {
+        let name: String
+        let extent: Int
+        let features: [Feature]
+    }
+
+    let layers: [Layer]
+
+    static func parse(data: Data) -> VectorTileParser? {
+        guard let raw = decompressIfNeeded(data) else { return nil }
+        var reader = ProtoReader(data: raw)
+        var layers: [Layer] = []
+        while !reader.isAtEnd {
+            guard let key = reader.readVarint() else { break }
+            let field = Int(key >> 3)
+            let wire = Int(key & 0x7)
+            if field == 3 && wire == 2, let ld = reader.readLengthDelimited() {
+                if let layer = parseLayer(data: ld) { layers.append(layer) }
+            } else {
+                reader.skip(wire: wire)
+            }
+        }
+        return VectorTileParser(layers: layers)
+    }
+
+    private static func decompressIfNeeded(_ data: Data) -> Data? {
+        if data.starts(with: [0x1f, 0x8b]) {
+            return gunzip(data)
+        }
+        return data
+    }
+
+    private static func gunzip(_ data: Data) -> Data? {
+        var dest = Data(count: 1_000_000)
+        let result = dest.withUnsafeMutableBytes { destPtr in
+            data.withUnsafeBytes { srcPtr in
+                compression_decode_buffer(destPtr.bindMemory(to: UInt8.self).baseAddress!,
+                                            dest.count,
+                                            srcPtr.bindMemory(to: UInt8.self).baseAddress!,
+                                            data.count,
+                                            nil,
+                                            COMPRESSION_ZLIB)
+            }
+        }
+        guard result > 0 else { return nil }
+        dest.removeSubrange(result..<dest.count)
+        return dest
+    }
+
+    private static func parseLayer(data: Data) -> Layer? {
+        var reader = ProtoReader(data: data)
+        var name = ""
+        var extent = 4096
+        var features: [Feature] = []
+        while !reader.isAtEnd {
+            guard let key = reader.readVarint() else { break }
+            let field = Int(key >> 3)
+            let wire = Int(key & 0x7)
+            switch field {
+            case 1: // name
+                if let d = reader.readLengthDelimited(), let s = String(data: d, encoding: .utf8) {
+                    name = s
+                }
+            case 2: // features
+                if let d = reader.readLengthDelimited(), let f = parseFeature(data: d) {
+                    features.append(f)
+                }
+            case 5: // extent
+                if let v = reader.readVarint() { extent = Int(v) }
+            default:
+                reader.skip(wire: wire)
+            }
+        }
+        return Layer(name: name, extent: extent, features: features)
+    }
+
+    private static func parseFeature(data: Data) -> Feature? {
+        var reader = ProtoReader(data: data)
+        var typeRaw: Int = 0
+        var geometryInts: [UInt32] = []
+        while !reader.isAtEnd {
+            guard let key = reader.readVarint() else { break }
+            let field = Int(key >> 3)
+            let wire = Int(key & 0x7)
+            switch field {
+            case 3:
+                if let v = reader.readVarint() { typeRaw = Int(v) }
+            case 4:
+                guard let len = reader.readVarint() else { return nil }
+                let end = reader.offset + Int(len)
+                while reader.offset < end {
+                    if let v = reader.readVarint() { geometryInts.append(UInt32(v)) } else { break }
+                }
+            default:
+                reader.skip(wire: wire)
+            }
+        }
+        let type = Feature.GeometryType(rawValue: typeRaw) ?? .unknown
+        let geom = decodeGeometry(geometryInts)
+        return Feature(type: type, geometry: geom)
+    }
+
+    private static func decodeGeometry(_ ints: [UInt32]) -> [[(Int, Int)]] {
+        var result: [[(Int, Int)]] = []
+        var ring: [(Int, Int)] = []
+        var x = 0
+        var y = 0
+        var i = 0
+        while i < ints.count {
+            let cmd = ints[i] & 0x7
+            var count = Int(ints[i] >> 3)
+            i += 1
+            switch cmd {
+            case 1: // MoveTo
+                if !ring.isEmpty { result.append(ring); ring.removeAll() }
+                for _ in 0..<count {
+                    let dx = zigZagDecode(ints[i]);
+                    let dy = zigZagDecode(ints[i+1]);
+                    i += 2
+                    x += dx; y += dy
+                    ring.append((x,y))
+                }
+            case 2: // LineTo
+                for _ in 0..<count {
+                    let dx = zigZagDecode(ints[i]);
+                    let dy = zigZagDecode(ints[i+1]);
+                    i += 2
+                    x += dx; y += dy
+                    ring.append((x,y))
+                }
+            case 7: // ClosePath
+                if !ring.isEmpty { result.append(ring); ring.removeAll() }
+            default:
+                break
+            }
+        }
+        if !ring.isEmpty { result.append(ring) }
+        return result
+    }
+
+    private static func zigZagDecode(_ n: UInt32) -> Int {
+        return Int((n >> 1) ^ (~(n & 1) + 1))
+    }
+}
+
+private struct ProtoReader {
+    let data: Data
+    var offset: Int = 0
+
+    var isAtEnd: Bool { offset >= data.count }
+
+    mutating func readVarint() -> UInt64? {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        while offset < data.count {
+            let b = data[offset]; offset += 1
+            result |= UInt64(b & 0x7F) << shift
+            if b & 0x80 == 0 { return result }
+            shift += 7
+        }
+        return nil
+    }
+
+    mutating func readLengthDelimited() -> Data? {
+        guard let len = readVarint() else { return nil }
+        guard offset + Int(len) <= data.count else { return nil }
+        let sub = data[offset..<offset+Int(len)]
+        offset += Int(len)
+        return Data(sub)
+    }
+
+    mutating func skip(wire: Int) {
+        switch wire {
+        case 0:
+            _ = readVarint()
+        case 1:
+            offset += 8
+        case 2:
+            if let len = readVarint() { offset += Int(len) }
+        case 5:
+            offset += 4
+        default:
+            break
+        }
+    }
+}

--- a/GPS LoggerTests/MBTilesVectorSourcePBFTests.swift
+++ b/GPS LoggerTests/MBTilesVectorSourcePBFTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import GPS_Logger
+import SQLite3
+import Compression
+
+final class MBTilesVectorSourcePBFTests: XCTestCase {
+    /// 簡単な PBF タイルを生成して MBTiles を作成
+    private func makeMBTiles() throws -> URL {
+        func varint(_ v: UInt64) -> Data {
+            var value = v
+            var data = Data()
+            while true {
+                let b = UInt8(value & 0x7F)
+                value >>= 7
+                if value != 0 {
+                    data.append(b | 0x80)
+                } else {
+                    data.append(b)
+                    break
+                }
+            }
+            return data
+        }
+        func command(id: UInt32, count: UInt32) -> UInt32 {
+            return (count << 3) | id
+        }
+        func zigzag(_ v: Int32) -> UInt32 {
+            return UInt32(bitPattern: (v << 1) ^ (v >> 31))
+        }
+
+        // geometry: MoveTo(0,0) LineTo(10,10)
+        var geom = Data()
+        [command(id:1,count:1), zigzag(0), zigzag(0),
+         command(id:2,count:1), zigzag(10), zigzag(10)].forEach { g in
+            geom.append(varint(UInt64(g)))
+        }
+
+        // feature
+        var feature = Data()
+        feature.append(varint(UInt64((3 << 3) | 0)))
+        feature.append(varint(UInt64(2))) // lineString
+        feature.append(varint(UInt64((4 << 3) | 2)))
+        feature.append(varint(UInt64(geom.count)))
+        feature.append(geom)
+
+        // layer
+        let name = "layer"
+        var layer = Data()
+        layer.append(varint(UInt64((1 << 3) | 2)))
+        layer.append(varint(UInt64(name.utf8.count)))
+        layer.append(name.data(using: .utf8)!)
+        layer.append(varint(UInt64((2 << 3) | 2)))
+        layer.append(varint(UInt64(feature.count)))
+        layer.append(feature)
+        layer.append(varint(UInt64((5 << 3) | 0)))
+        layer.append(varint(4096))
+
+        // tile
+        var tile = Data()
+        tile.append(varint(UInt64((3 << 3) | 2)))
+        tile.append(varint(UInt64(layer.count)))
+        tile.append(layer)
+
+        // gzip compress
+        var encoded = Data(count: compression_encode_scratch_buffer_size(COMPRESSION_ZLIB))
+        var out = Data(count: tile.count + 64)
+        let result = out.withUnsafeMutableBytes { outPtr in
+            tile.withUnsafeBytes { inPtr in
+                compression_encode_buffer(outPtr.bindMemory(to: UInt8.self).baseAddress!, out.count,
+                                           inPtr.bindMemory(to: UInt8.self).baseAddress!, tile.count,
+                                           encoded.withUnsafeMutableBytes { $0.baseAddress },
+                                           COMPRESSION_ZLIB)
+            }
+        }
+        out.removeSubrange(result..<out.count)
+        let pbf = out
+
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test_pbf.mbtiles")
+        var db: OpaquePointer? = nil
+        sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        defer { if let db = db { sqlite3_close(db) } }
+        sqlite3_exec(db, "CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);", nil, nil, nil)
+        var stmt: OpaquePointer? = nil
+        sqlite3_prepare_v2(db, "INSERT INTO tiles VALUES (0,0,0,?)", -1, &stmt, nil)
+        pbf.withUnsafeBytes { ptr in
+            sqlite3_bind_blob(stmt, 1, ptr.baseAddress, Int32(pbf.count), nil)
+        }
+        sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        return url
+    }
+
+    func testLoadPBF() throws {
+        let url = try makeMBTiles()
+        guard let src = MBTilesVectorSource(url: url, zoomLevel: 0) else {
+            XCTFail("failed to open pbf mbtiles")
+            return
+        }
+        let overlays = src.overlays(in: MKMapRect.world)
+        XCTAssertEqual(overlays.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- support gzipped PBF vector tiles in `MBTilesVectorSource`
- implement a lightweight Mapbox Vector Tile parser
- add unit test generating a simple PBF tile

## Testing
- `swift test` *(fails: unable to clone swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_68451f1732208326b3dac49d2a1b6046