### PR TITLE
Fix compile warnings and update overlay selection handling

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -124,7 +124,9 @@ final class AirspaceManager: ObservableObject {
                 result.append(contentsOf: src.overlays(in: currentMapRect))
             }
         }
-        displayOverlays = result
+        DispatchQueue.main.async {
+            self.displayOverlays = result
+        }
     }
 
     /// MapView から現在の表示範囲を受け取る

--- a/GPS Logger/Airspace/VectorTileParser.swift
+++ b/GPS Logger/Airspace/VectorTileParser.swift
@@ -49,10 +49,11 @@ struct VectorTileParser {
 
     private static func gunzip(_ data: Data) -> Data? {
         var dest = Data(count: 1_000_000)
+        let destCount = dest.count
         let result = dest.withUnsafeMutableBytes { destPtr in
             data.withUnsafeBytes { srcPtr in
                 compression_decode_buffer(destPtr.bindMemory(to: UInt8.self).baseAddress!,
-                                            dest.count,
+                                            destCount,
                                             srcPtr.bindMemory(to: UInt8.self).baseAddress!,
                                             data.count,
                                             nil,
@@ -125,7 +126,7 @@ struct VectorTileParser {
         var i = 0
         while i < ints.count {
             let cmd = ints[i] & 0x7
-            var count = Int(ints[i] >> 3)
+            let count = Int(ints[i] >> 3)
             i += 1
             switch cmd {
             case 1: // MoveTo

--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -163,13 +163,24 @@ struct ContentView: View {
                         Text("風情報なし")
                     }
 
-                    Stepper(value: $pressureInput, in: -10000...60000, step: 500) {
-                        Text("気圧高度: \(pressureInput) ft")
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .onChange(of: pressureInput) { newValue in
-                        pressureAltitude = Double(newValue)
-                        locationManager.pressureAltitudeFt = pressureAltitude
+                    if #available(iOS 17.0, *) {
+                        Stepper(value: $pressureInput, in: -10000...60000, step: 500) {
+                            Text("気圧高度: \(pressureInput) ft")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .onChange(of: pressureInput, initial: false) { _, newValue in
+                            pressureAltitude = Double(newValue)
+                            locationManager.pressureAltitudeFt = pressureAltitude
+                        }
+                    } else {
+                        Stepper(value: $pressureInput, in: -10000...60000, step: 500) {
+                            Text("気圧高度: \(pressureInput) ft")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .onChange(of: pressureInput) { newValue in
+                            pressureAltitude = Double(newValue)
+                            locationManager.pressureAltitudeFt = pressureAltitude
+                        }
                     }
 
                     // 推算CAS/TAS/OAT/Mach 表示

--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -125,6 +125,7 @@ struct MapViewRepresentable: UIViewRepresentable {
             return MKOverlayRenderer(overlay: overlay)
         }
 
+        @available(iOS 17.0, *)
         func mapView(_ mapView: MKMapView, didSelect overlay: MKOverlay) {
             guard let shape = overlay as? MKShape,
                   let title = shape.title else { return }
@@ -137,6 +138,7 @@ struct MapViewRepresentable: UIViewRepresentable {
             mapView.addAnnotation(ann)
         }
 
+        @available(iOS 17.0, *)
         func mapView(_ mapView: MKMapView, didDeselect overlay: MKOverlay) {
             if let ann = infoAnnotation {
                 mapView.removeAnnotation(ann)


### PR DESCRIPTION
## Summary
- fix overlapping access in `VectorTileParser` by caching `dest.count`
- change immutable variable to `let`
- gate overlay selection delegate methods with iOS 17 availability
- update pressure input change handler for iOS 17 and earlier
- avoid publishing `@Published` changes during view updates

## Testing
- `swift test -c release` *(fails: unable to fetch `swift-testing` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_684522aedf3c8326ae1a775a46b5fc1e