### PR TITLE
Implement cache limit for MBTilesVectorSource

### DIFF
--- a/GPS LoggerTests/MBTilesVectorSourceTests.swift
+++ b/GPS LoggerTests/MBTilesVectorSourceTests.swift
@@ -19,6 +19,28 @@ final class MBTilesVectorSourceTests: XCTestCase {
         return url
     }
 
+    /// 2 タイル分のデータを持つ MBTiles ファイルを生成
+    private func makeMultiTiles() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test_multi.mbtiles")
+        var db: OpaquePointer? = nil
+        sqlite3_open_v2(url.path, &db, SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE, nil)
+        defer { if let db = db { sqlite3_close(db) } }
+        sqlite3_exec(db, "CREATE TABLE tiles (zoom_level INTEGER, tile_column INTEGER, tile_row INTEGER, tile_data BLOB);", nil, nil, nil)
+        let json = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[0,0],[0.1,0.1]]}}]}"
+        var stmt: OpaquePointer? = nil
+        // タイル (0,0)
+        sqlite3_prepare_v2(db, "INSERT INTO tiles VALUES (1,0,1,?)", -1, &stmt, nil)
+        sqlite3_bind_blob(stmt, 1, json, Int32(json.utf8.count), nil)
+        sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        // タイル (1,0)
+        sqlite3_prepare_v2(db, "INSERT INTO tiles VALUES (1,1,1,?)", -1, &stmt, nil)
+        sqlite3_bind_blob(stmt, 1, json, Int32(json.utf8.count), nil)
+        sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+        return url
+    }
+
     func testLoadTile() throws {
         let url = try makeMBTiles()
         guard let src = MBTilesVectorSource(url: url) else {
@@ -27,5 +49,19 @@ final class MBTilesVectorSourceTests: XCTestCase {
         }
         let overlays = src.overlays(in: MKMapRect.world)
         XCTAssertEqual(overlays.count, 1)
+    }
+
+    func testCacheLimit() throws {
+        let url = try makeMultiTiles()
+        guard let src = MBTilesVectorSource(url: url, zoomLevel: 1, cacheLimit: 1) else {
+            XCTFail("failed to open mbtiles")
+            return
+        }
+        let half = MKMapRect(x: 0, y: 0, width: MKMapRect.world.width / 2, height: MKMapRect.world.height / 2)
+        _ = src.overlays(in: half)
+        XCTAssertEqual(src.cacheCount, 1)
+        let half2 = MKMapRect(x: MKMapRect.world.midX, y: 0, width: MKMapRect.world.width / 2, height: MKMapRect.world.height / 2)
+        _ = src.overlays(in: half2)
+        XCTAssertEqual(src.cacheCount, 1)
     }
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Flight Assist 画面では、計測値を検証するためにグランドトラ
 ## Map Overlays
 
 The app displays a basemap from an MBTiles file and optional airspace overlays from GeoJSON or vector MBTiles files. Data placed in the `Airspace` directory is loaded when the map view is created. Each file is treated as a category identified by its filename without the extension. GeoJSON files are parsed on a background thread and converted to `MKPolyline` or `MKPolygon` objects. Vector MBTiles are read tile by tile so only features within the current map view are loaded.
+`MBTilesVectorSource` は読み込んだタイルを内部でキャッシュしており、`cacheLimit` プロパティで保持数を指定できます。上限を超えた場合は古いタイルから削除されます。
 
 When you open the map screen, tap the stack icon in the toolbar to show the layer settings. A list of categories appears and you can toggle each overlay on or off. The map refreshes immediately to reflect your choices.
 


### PR DESCRIPTION
## Summary
- add `cacheLimit` property with LRU eviction to `MBTilesVectorSource`
- expose `cacheCount` for testing
- extend MBTilesVectorSource tests with cache limit check
- document cache limit in README

## Testing
- `swift test` *(fails: unable to fetch swift-testing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68452d4e552c8326acb9847928c229f0