### PR TITLE
Improve airspace loading message

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -48,6 +48,10 @@ final class AirspaceManager: ObservableObject {
                 files = jsons + mbts
             }
 
+            if files.isEmpty {
+                print("[AirspaceManager] No airspace data found in bundle")
+            }
+
             var map: [String: [MKOverlay]] = [:]
             var sources: [String: MBTilesVectorSource] = [:]
             for url in files {

--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ The app displays a basemap from an MBTiles file and optional airspace overlays f
 When you open the map screen, tap the stack icon in the toolbar to show the layer settings. A list of categories appears and you can toggle each overlay on or off. The map refreshes immediately to reflect your choices.
 
 Only `LineString` and `Polygon` features are supported. Multi‑geometry types are ignored. To add new data, bundle additional GeoJSON or vector MBTiles files in the `Airspace` folder.
+
+**Note:** サンプルの空域データはリポジトリに含まれていません。`Airspace` フォルダへ GeoJSON または MBTiles ファイルを配置してからビルドしてください。ファイルが存在しない場合、マップ上にはベースマップのみが表示されます。


### PR DESCRIPTION
## Summary
- log a message when no Airspace resources are found
- document that sample airspace data is not bundled and must be added manually

## Testing
- `swift build` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684567c6c6c08326a774b4b22bef2144