### PR TITLE
Fix airspace bundle search

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             resources: [
                 .process("Assets.xcassets"),
                 .process("Preview Content"),
-                .process("Airspace")
+                .copy("Airspace")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary
- copy `Airspace` folder in Swift package manifest so the directory structure is preserved

## Testing
- `swift package describe`
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_68457fc69d848326b6b9198cd3f017c2