### PR TITLE
Fix resource lookup for Airspace data

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -43,10 +43,10 @@ final class AirspaceManager: ObservableObject {
             if let urls = urls {
                 files = urls
             } else {
-                let bundleDir = Bundle.module.resourceURL?.appendingPathComponent("Airspace")
+                let bundleDir = Bundle.module.resourceURL
                 print("[AirspaceManager] Searching bundle at", bundleDir?.path ?? "nil")
-                let jsons = Bundle.module.urls(forResourcesWithExtension: "geojson", subdirectory: "Airspace") ?? []
-                let mbts = Bundle.module.urls(forResourcesWithExtension: "mbtiles", subdirectory: "Airspace") ?? []
+                let jsons = Bundle.module.urls(forResourcesWithExtension: "geojson", subdirectory: nil) ?? []
+                let mbts = Bundle.module.urls(forResourcesWithExtension: "mbtiles", subdirectory: nil) ?? []
                 files = jsons + mbts
 
                 if files.isEmpty {


### PR DESCRIPTION
## Summary
- search resources at bundle root instead of `Airspace` subdirectory

## Testing
- `swift test` *(fails: unable to access external dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6846db078bf88326baf2f3b63e53f496