### PR TITLE
Fix MapView coordinator settings reference

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -95,16 +95,18 @@ struct MapViewRepresentable: UIViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(airspaceManager: airspaceManager)
+        Coordinator(airspaceManager: airspaceManager, settings: settings)
     }
 
     class Coordinator: NSObject, MKMapViewDelegate {
         private var infoAnnotation: MKPointAnnotation?
         private let airspaceManager: AirspaceManager
+        private let settings: Settings
         var regionSet = false
 
-        init(airspaceManager: AirspaceManager) {
+        init(airspaceManager: AirspaceManager, settings: Settings) {
             self.airspaceManager = airspaceManager
+            self.settings = settings
         }
 
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {


### PR DESCRIPTION
## Summary
- pass `Settings` to `MapViewRepresentable.Coordinator`
- store settings in the coordinator

## Testing
- `swift test` *(fails: failed to clone repository https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6846e459d80483269d667ffc0c89b535