### PR TITLE
Fix MKShape import and refactor MapLayerSettingsView

### DIFF
--- a/GPS Logger/Map/MapLayerSettingsView.swift
+++ b/GPS Logger/Map/MapLayerSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import MapKit
 
 /// 空域レイヤの表示設定を行う画面
 struct MapLayerSettingsView: View {
@@ -9,56 +10,69 @@ struct MapLayerSettingsView: View {
         Form {
             if !airspaceManager.categories.isEmpty {
                 Section(header: Text("空域レイヤ")) {
-                    ForEach(airspaceManager.categories, id: \.​self) { category in
-                        VStack(alignment: .leading) {
-                            Toggle(category, isOn: Binding(
-                                get: { settings.enabledAirspaceCategories.contains(category) },
-                                set: { newValue in
-                                    if newValue {
-                                        if !settings.enabledAirspaceCategories.contains(category) {
-                                            settings.enabledAirspaceCategories.append(category)
-                                        }
-                                    } else {
-                                        settings.enabledAirspaceCategories.removeAll { $0 == category }
-                                    }
-                                }
-                            ))
-
-                            if settings.enabledAirspaceCategories.contains(category) {
-                                let features = airspaceManager.features(in: category)
-                                ForEach(features.indices, id: \.​self) { idx in
-                                    let overlay = features[idx]
-                                    let fid = (overlay as? FeaturePolyline)?.featureID ?? (overlay as? FeaturePolygon)?.featureID ?? (overlay as? FeatureCircle)?.featureID ?? "\(idx)"
-                                    let title = (overlay as? MKShape)?.title ?? "Feature \(idx)"
-                                    Toggle("  " + title, isOn: Binding(
-                                        get: { !(settings.hiddenFeatureIDs[category] ?? []).contains(fid) },
-                                        set: { val in
-                                            var list = settings.hiddenFeatureIDs[category] ?? []
-                                            if val {
-                                                list.removeAll { $0 == fid }
-                                            } else {
-                                                if !list.contains(fid) { list.append(fid) }
-                                            }
-                                            settings.hiddenFeatureIDs[category] = list
-                                        }
-                                    ))
-                                }
-
-                                ColorPicker("線色", selection: Binding(
-                                    get: { Color(hex: settings.airspaceStrokeColors[category] ?? "FF0000FF") ?? .red },
-                                    set: { color in settings.airspaceStrokeColors[category] = color.hexString }
-                                ))
-                                ColorPicker("塗り色", selection: Binding(
-                                    get: { Color(hex: settings.airspaceFillColors[category] ?? "FF000055") ?? .blue.opacity(0.2) },
-                                    set: { color in settings.airspaceFillColors[category] = color.hexString }
-                                ))
-                            }
-                        }
+                    ForEach(airspaceManager.categories, id: \.self) { category in
+                        CategorySettingsView(category: category)
                     }
                 }
             }
         }
         .navigationTitle("レイヤ設定")
+    }
+}
+
+private struct CategorySettingsView: View {
+    @EnvironmentObject var settings: Settings
+    @EnvironmentObject var airspaceManager: AirspaceManager
+    let category: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Toggle(category, isOn: Binding(
+                get: { settings.enabledAirspaceCategories.contains(category) },
+                set: { newValue in
+                    if newValue {
+                        if !settings.enabledAirspaceCategories.contains(category) {
+                            settings.enabledAirspaceCategories.append(category)
+                        }
+                    } else {
+                        settings.enabledAirspaceCategories.removeAll { $0 == category }
+                    }
+                }
+            ))
+
+            if settings.enabledAirspaceCategories.contains(category) {
+                let features = airspaceManager.features(in: category)
+                ForEach(features.indices, id: \.self) { idx in
+                    let overlay = features[idx]
+                    let fid = (overlay as? FeaturePolyline)?.featureID ??
+                              (overlay as? FeaturePolygon)?.featureID ??
+                              (overlay as? FeatureCircle)?.featureID ??
+                              "\(idx)"
+                    let title = (overlay as? MKShape)?.title ?? "Feature \(idx)"
+                    Toggle("  " + title, isOn: Binding(
+                        get: { !(settings.hiddenFeatureIDs[category] ?? []).contains(fid) },
+                        set: { val in
+                            var list = settings.hiddenFeatureIDs[category] ?? []
+                            if val {
+                                list.removeAll { $0 == fid }
+                            } else {
+                                if !list.contains(fid) { list.append(fid) }
+                            }
+                            settings.hiddenFeatureIDs[category] = list
+                        }
+                    ))
+                }
+
+                ColorPicker("線色", selection: Binding(
+                    get: { Color(hex: settings.airspaceStrokeColors[category] ?? "FF0000FF") ?? .red },
+                    set: { color in settings.airspaceStrokeColors[category] = color.hexString }
+                ))
+                ColorPicker("塗り色", selection: Binding(
+                    get: { Color(hex: settings.airspaceFillColors[category] ?? "FF000055") ?? .blue.opacity(0.2) },
+                    set: { color in settings.airspaceFillColors[category] = color.hexString }
+                ))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `MapKit` import to access `MKShape`
- split airspace layer UI into `CategorySettingsView` for simpler type checking

## Testing
- `swift build` *(fails: unable to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6846e57e14148326990e56bceb4580fb