### PR TITLE
Add map layer group toggles

### DIFF
--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -40,6 +40,9 @@ final class Settings: ObservableObject {
     /// 表示する空域カテゴリ
     @UserDefaultBacked(key: "enabledAirspaceCategories") var enabledAirspaceCategories: [String] = []
 
+    /// 有効化された空域グループ
+    @UserDefaultBacked(key: "enabledAirspaceGroups") var enabledAirspaceGroups: [String] = []
+
     /// 非表示フィーチャ ID
     @UserDefaultBacked(key: "hiddenFeatureIDs") var hiddenFeatureIDs: [String: [String]] = [:]
     /// 線色設定
@@ -140,6 +143,10 @@ final class Settings: ObservableObject {
             .store(in: &cancellables)
 
         $enabledAirspaceCategories
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $enabledAirspaceGroups
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
 


### PR DESCRIPTION
## Summary
- support grouping categories in `AirspaceManager`
- save enabled airspace groups in `Settings`
- show groups in `MapLayerSettingsView` with group toggles

## Testing
- `swift build` *(fails: unable to access https://github.com/apple/swift-testing.git)*
- `swift test` *(fails: unable to access https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6846e814029883269eb94f0a60e62661