### PR TITLE
Fix featureGroups nil-coalescing

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -48,7 +48,10 @@ final class AirspaceManager: ObservableObject {
 
     /// 指定カテゴリで利用可能なフィーチャグループ名一覧
     func featureGroups(in category: String) -> [String] {
-        Array(featureGroupsByCategory[category]?.keys ?? []).sorted()
+        guard let keys = featureGroupsByCategory[category]?.keys else {
+            return []
+        }
+        return Array(keys).sorted()
     }
 
     /// 指定カテゴリとグループの全オーバーレイ


### PR DESCRIPTION
## Summary
- fix usage of dictionary keys when fetching feature group names

## Testing
- `swift test -c debug` *(fails: unable to fetch dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee6630c883268e4442a2e1c169c6