### PR TITLE
Use loaded airspace data for HUD

### DIFF
--- a/GPS Logger/Airspace/AirspaceSlim.swift
+++ b/GPS Logger/Airspace/AirspaceSlim.swift
@@ -1,0 +1,44 @@
+import Foundation
+import CoreLocation
+
+/// airspace_slim.json のエントリを表す構造体
+struct AirspaceSlim: Codable, Identifiable {
+    let id: String
+    let name: String
+    let sub: String
+    let icon: String
+    let upper: String
+    let lower: String
+    let bbox: [Double]    // [minLon, minLat, maxLon, maxLat]
+    let active: Bool?
+}
+
+/// 高度文字列をメートル単位で返す。"FL100" や "5000ft" 等に対応
+func alt_m(_ s: String) -> Int {
+    let lower = s.lowercased()
+    if lower.hasPrefix("fl"), let val = Int(lower.dropFirst(2)) {
+        return Int(Double(val) * 100.0 * 0.3048)
+    }
+    if lower.hasSuffix("ft"), let val = Int(lower.dropLast(2)) {
+        return Int(Double(val) * 0.3048)
+    }
+    return Int(Double(lower) ?? 0.0)
+}
+
+/// 指定座標が bbox 内に含まれるか判定
+func contains(_ coord: CLLocationCoordinate2D, bbox: [Double]) -> Bool {
+    guard bbox.count == 4 else { return false }
+    return coord.longitude >= bbox[0] && coord.longitude <= bbox[2] &&
+           coord.latitude >= bbox[1] && coord.latitude <= bbox[3]
+}
+
+/// 現在時刻に対して空域が有効か判定。active フィールドが無ければ常に true
+func is_active(_ asp: AirspaceSlim, now: Date = Date()) -> Bool {
+    return asp.active ?? true
+}
+
+/// 軍事空域かどうかを大まかに判定し、優先度として数値を返す
+/// ここでは icon が "M" で始まる場合を軍事扱いとする簡易実装
+func milRank(_ asp: AirspaceSlim) -> Int {
+    asp.icon.uppercased().hasPrefix("M") ? 0 : 1
+}

--- a/GPS Logger/Airspace/HUDView.swift
+++ b/GPS Logger/Airspace/HUDView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import CoreLocation
+
+/// HUD 表示を行う View
+struct HUDView: View {
+    @ObservedObject var viewModel: HUDViewModel
+    var body: some View {
+        VStack(spacing: 4) {
+            ForEach(viewModel.hudRows, id: \.self) { row in
+                Text(row)
+                    .font(.caption2.monospaced())
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+        .padding(8)
+        .background(Color.black.opacity(0.5))
+        .cornerRadius(8)
+    }
+}
+
+/// Map タップ時に表示する一覧
+struct StackChipView: View {
+    let list: [AirspaceSlim]
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(list) { asp in
+                Text(String(format: "%@-%@ %-4@ %@", asp.upper, asp.lower, asp.sub, asp.icon))
+                    .font(.caption2.monospaced())
+            }
+        }
+        .padding(8)
+        .background(Color.black.opacity(0.7))
+        .cornerRadius(8)
+    }
+}

--- a/GPS Logger/Airspace/HUDViewModel.swift
+++ b/GPS Logger/Airspace/HUDViewModel.swift
@@ -1,0 +1,120 @@
+import Foundation
+import CoreLocation
+import SwiftUI
+import Combine
+
+/// HUD 更新ロジックを担当する ViewModel
+final class HUDViewModel: ObservableObject {
+    @Published var hudRows: [String] = []
+    @Published var stackList: [AirspaceSlim] = []
+    @Published var showStack: Bool = false
+    @Published var zoneQueryOn: Bool = false
+    private var lastPos: CLLocationCoordinate2D?
+    private var lastAlt: Double?
+    private var lastTS: Date?
+    private var hudIDs: [String] = []
+    private let thresholdDist: Double = 500.0  // m
+    private let thresholdAlt: Double = 100.0   // m
+    private let thresholdTime: TimeInterval = 60.0
+    private var airspaces: [AirspaceSlim] = []
+    private var cancellables = Set<AnyCancellable>()
+    init(airspaceManager: AirspaceManager) {
+        self.airspaces = airspaceManager.slimList
+        airspaceManager.$slimList
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] list in
+                self?.airspaces = list
+            }
+            .store(in: &cancellables)
+    }
+
+    /// 新しい位置情報を受け取って HUD 更新判定を行う
+    func onNewGPSSample(_ loc: CLLocation) {
+        let pos = loc.coordinate
+        let alt = loc.altitude
+        let now = Date()
+        if let lp = lastPos, let la = lastAlt, let lt = lastTS {
+            let dist = CLLocation(latitude: lp.latitude, longitude: lp.longitude)
+                .distance(from: CLLocation(latitude: pos.latitude, longitude: pos.longitude))
+            let altDiff = abs(alt - la)
+            let dt = now.timeIntervalSince(lt)
+            if dist <= thresholdDist && altDiff <= thresholdAlt && dt <= thresholdTime {
+                return
+            }
+        }
+        let newIDs = queryActive(pos: pos, alt: alt, now: now)
+        if newIDs != hudIDs {
+            hudStripUpdate(ids: newIDs)
+            hudIDs = newIDs
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
+        lastPos = pos
+        lastAlt = alt
+        lastTS = now
+    }
+
+    private func hudStripUpdate(ids: [String]) {
+        let asps = airspaces.filter { ids.contains($0.id) }
+        let rows = asps.sorted { a, b in
+            if alt_m(a.upper) != alt_m(b.upper) {
+                return alt_m(a.upper) > alt_m(b.upper)
+            }
+            if milRank(a) != milRank(b) {
+                return milRank(a) < milRank(b)
+            }
+            return a.name < b.name
+        }.prefix(3).map { asp in
+            String(format: "%@-%@ %-4@ %@", asp.upper, asp.lower, asp.sub, asp.icon)
+        }
+        self.hudRows = Array(rows)
+    }
+
+    /// 現在位置から有効空域 ID 一覧を返す
+    private func queryActive(pos: CLLocationCoordinate2D, alt: Double, now: Date) -> [String] {
+        var list: [AirspaceSlim] = []
+        for asp in airspaces {
+            guard contains(pos, bbox: asp.bbox) else { continue }
+            guard is_active(asp, now: now) else { continue }
+            let upper = alt_m(asp.upper)
+            let lower = alt_m(asp.lower)
+            if Int(alt) <= upper && Int(alt) >= lower {
+                list.append(asp)
+            }
+        }
+        list.sort { a, b in
+            if alt_m(a.upper) != alt_m(b.upper) {
+                return alt_m(a.upper) > alt_m(b.upper)
+            }
+            if milRank(a) != milRank(b) {
+                return milRank(a) < milRank(b)
+            }
+            return a.name < b.name
+        }
+        return list.map { $0.id }
+    }
+
+    /// Map 画面でタップされた位置を処理
+    func onMapTap(_ coord: CLLocationCoordinate2D) {
+        guard zoneQueryOn else { return }
+        var hit: [AirspaceSlim] = []
+        for asp in airspaces {
+            if contains(coord, bbox: asp.bbox) {
+                hit.append(asp)
+            }
+        }
+        hit.sort { a, b in
+            if alt_m(a.upper) != alt_m(b.upper) {
+                return alt_m(a.upper) > alt_m(b.upper)
+            }
+            if milRank(a) != milRank(b) {
+                return milRank(a) < milRank(b)
+            }
+            return a.name < b.name
+        }
+        self.stackList = Array(hit.prefix(4))
+        self.showStack = !stackList.isEmpty
+        if showStack {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
+    }
+}

--- a/GPS Logger/Airspace/airspace_slim.json
+++ b/GPS Logger/Airspace/airspace_slim.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "A1",
+    "name": "Area Alpha",
+    "sub": "CTR",
+    "icon": "M1",
+    "upper": "FL200",
+    "lower": "0ft",
+    "bbox": [139.5, 35.5, 140.5, 36.0],
+    "active": true
+  },
+  {
+    "id": "B1",
+    "name": "Area Bravo",
+    "sub": "TCA",
+    "icon": "C",
+    "upper": "FL150",
+    "lower": "1000ft",
+    "bbox": [139.0, 35.0, 139.7, 35.7],
+    "active": true
+  },
+  {
+    "id": "C1",
+    "name": "Area Charlie",
+    "sub": "R",
+    "icon": "M2",
+    "upper": "FL300",
+    "lower": "5000ft",
+    "bbox": [140.0, 36.0, 140.8, 36.5],
+    "active": false
+  }
+]


### PR DESCRIPTION
## Summary
- expose slimList from AirspaceManager
- build AirspaceSlim entries from GeoJSON overlays
- observe slimList in HUDViewModel
- pass AirspaceManager into HUDViewModel

## Testing
- `swift build` *(fails: failed to clone https://github.com/apple/swift-testing.git)*
- `swift test` *(fails: failed to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_68475a8738d083269a4d474fab6ece05