### PR TITLE
Fix MKCoordinateForMapPoint deprecation

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -454,8 +454,8 @@ final class AirspaceManager: ObservableObject {
                 let icon = (typ == 2 || typ == 4) ? "M" : "C"
 
                 let rect = ov.boundingMapRect
-                let sw = MKCoordinateForMapPoint(MKMapPoint(x: rect.minX, y: rect.minY))
-                let ne = MKCoordinateForMapPoint(MKMapPoint(x: rect.maxX, y: rect.maxY))
+                let sw = MKMapPoint(x: rect.minX, y: rect.minY).coordinate
+                let ne = MKMapPoint(x: rect.maxX, y: rect.maxY).coordinate
                 let bbox = [sw.longitude, sw.latitude, ne.longitude, ne.latitude]
 
                 let asp = AirspaceSlim(id: fid, name: name, sub: sub, icon: icon,


### PR DESCRIPTION
## Summary
- replace `MKCoordinateForMapPoint` with `MKMapPoint.coordinate` in `AirspaceManager`

## Testing
- `swift test` *(fails: unable to fetch dependency due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68475eb79e1883268914711d5d6377b3