### PR TITLE
Fix HUD to use overlays

### DIFF
--- a/GPS Logger/Airspace/HUDViewModel.swift
+++ b/GPS Logger/Airspace/HUDViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreLocation
 import SwiftUI
 import Combine
+import MapKit
 
 /// HUD 更新ロジックを担当する ViewModel
 final class HUDViewModel: ObservableObject {
@@ -18,12 +19,13 @@ final class HUDViewModel: ObservableObject {
     private let thresholdTime: TimeInterval = 60.0
     private var airspaces: [AirspaceSlim] = []
     private var cancellables = Set<AnyCancellable>()
+
     init(airspaceManager: AirspaceManager) {
-        self.airspaces = airspaceManager.slimList
-        airspaceManager.$slimList
+        self.airspaces = Self.buildSlimList(from: airspaceManager.overlaysByCategory)
+        airspaceManager.$overlaysByCategory
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] list in
-                self?.airspaces = list
+            .sink { [weak self] map in
+                self?.airspaces = Self.buildSlimList(from: map)
             }
             .store(in: &cancellables)
     }
@@ -116,5 +118,58 @@ final class HUDViewModel: ObservableObject {
         if showStack {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
         }
+    }
+
+    /// AirspaceManager のオーバーレイ情報から簡易リストを生成
+    private static func buildSlimList(from map: [String: [MKOverlay]]) -> [AirspaceSlim] {
+        func altString(_ info: [String: Any]?) -> String {
+            guard let info = info,
+                  let value = info["value"] as? Int,
+                  let unit = info["unit"] as? Int else { return "0ft" }
+            if unit == 6 { return "FL\(value)" }
+            return "\(value)ft"
+        }
+
+        var result: [AirspaceSlim] = []
+        for (cat, overlays) in map {
+            for ov in overlays {
+                var props: [String: Any] = [:]
+                var fid: String = UUID().uuidString
+                var name: String = cat
+                var sub: String = cat
+                if let p = ov as? FeaturePolyline {
+                    props = p.properties
+                    fid = p.featureID
+                    name = p.title ?? cat
+                    sub = p.subtitle ?? cat
+                } else if let p = ov as? FeaturePolygon {
+                    props = p.properties
+                    fid = p.featureID
+                    name = p.title ?? cat
+                    sub = p.subtitle ?? cat
+                } else if let c = ov as? FeatureCircle {
+                    props = c.properties
+                    fid = c.featureID
+                    name = c.title ?? cat
+                    sub = c.subtitle ?? cat
+                } else { continue }
+
+                let upper = altString(props["upperLimit"] as? [String: Any])
+                let lower = altString(props["lowerLimit"] as? [String: Any])
+
+                let typ = props["type"] as? Int ?? 0
+                let icon = (typ == 2 || typ == 4) ? "M" : "C"
+
+                let rect = ov.boundingMapRect
+                let sw = MKMapPoint(x: rect.minX, y: rect.minY).coordinate
+                let ne = MKMapPoint(x: rect.maxX, y: rect.maxY).coordinate
+                let bbox = [sw.longitude, sw.latitude, ne.longitude, ne.latitude]
+
+                let asp = AirspaceSlim(id: fid, name: name, sub: sub, icon: icon,
+                                      upper: upper, lower: lower, bbox: bbox, active: true)
+                result.append(asp)
+            }
+        }
+        return result
     }
 }


### PR DESCRIPTION
## Summary
- update HUDViewModel to generate slim airspace list from AirspaceManager overlays
- new helper converts overlay data on the fly

## Testing
- `swift test --enable-test-discovery` *(fails: unable to clone swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_684820dc3e3c8326ad352eab672b1ddd