### PR TITLE
Improve HUD data initialization

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -164,6 +164,7 @@ final class AirspaceManager: ObservableObject {
                 print("enabled categories:", self.settings.enabledAirspaceCategories)
                 self.updateDisplayOverlays()
                 self.slimList = self.buildSlimList(from: map)
+                print("[AirspaceManager] slimList count:", self.slimList.count)
             }
         }
     }


### PR DESCRIPTION
## Summary
- hook HUD view model to `AirspaceManager`'s `slimList`
- log when GPS samples and zone taps occur
- log slim list count after loading

## Testing
- `swift test` *(fails: unable to clone swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_6848311934c4832686483d089e1e788c