### PR TITLE
Fix bounding box orientation for airspace tap detection

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -455,8 +455,8 @@ final class AirspaceManager: ObservableObject {
                 let icon = (typ == 2 || typ == 4) ? "M" : "C"
 
                 let rect = ov.boundingMapRect
-                let sw = MKMapPoint(x: rect.minX, y: rect.minY).coordinate
-                let ne = MKMapPoint(x: rect.maxX, y: rect.maxY).coordinate
+                let sw = MKMapPoint(x: rect.minX, y: rect.maxY).coordinate
+                let ne = MKMapPoint(x: rect.maxX, y: rect.minY).coordinate
                 let bbox = [sw.longitude, sw.latitude, ne.longitude, ne.latitude]
 
                 let asp = AirspaceSlim(id: fid, name: name, sub: sub, icon: icon,

--- a/GPS Logger/Airspace/HUDViewModel.swift
+++ b/GPS Logger/Airspace/HUDViewModel.swift
@@ -166,8 +166,8 @@ final class HUDViewModel: ObservableObject {
                 let icon = (typ == 2 || typ == 4) ? "M" : "C"
 
                 let rect = ov.boundingMapRect
-                let sw = MKMapPoint(x: rect.minX, y: rect.minY).coordinate
-                let ne = MKMapPoint(x: rect.maxX, y: rect.maxY).coordinate
+                let sw = MKMapPoint(x: rect.minX, y: rect.maxY).coordinate
+                let ne = MKMapPoint(x: rect.maxX, y: rect.minY).coordinate
                 let bbox = [sw.longitude, sw.latitude, ne.longitude, ne.latitude]
 
                 let asp = AirspaceSlim(id: fid, name: name, sub: sub, icon: icon,


### PR DESCRIPTION
## Summary
- correct bounding box calculation so south-west and north-east corners are computed properly

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6848356afeec832682efd714cbc5f7dd