### PR TITLE
Add navigation models and map HUD elements

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -11,6 +11,8 @@ struct MainMapView: View {
     @StateObject var airspaceManager: AirspaceManager
     @State private var showLayerSettings = false
     @StateObject private var hudViewModel: HUDViewModel
+    @State private var waypoint: Waypoint? = nil
+    @State private var navInfo: NavComputed? = nil
 
     init() {
         let settings = Settings()
@@ -33,9 +35,23 @@ struct MainMapView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                MapViewRepresentable(locationManager: locationManager, airspaceManager: airspaceManager, settings: settings, hudViewModel: hudViewModel)
+                MapViewRepresentable(locationManager: locationManager,
+                                    airspaceManager: airspaceManager,
+                                    settings: settings,
+                                    hudViewModel: hudViewModel,
+                                    waypoint: $waypoint,
+                                    navInfo: $navInfo)
                     .ignoresSafeArea()
 
+                if let nav = navInfo {
+                    TargetBannerView(nav: nav)
+                        .position(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY)
+                }
+
+                StatusRibbonView(locationManager: locationManager)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 10)
+            
                 VStack {
                     Spacer()
                     HStack {
@@ -103,6 +119,8 @@ struct MapViewRepresentable: UIViewRepresentable {
     @ObservedObject var airspaceManager: AirspaceManager
     @ObservedObject var settings: Settings
     @ObservedObject var hudViewModel: HUDViewModel
+    @Binding var waypoint: Waypoint?
+    @Binding var navInfo: NavComputed?
 
     func makeUIView(context: Context) -> MKMapView {
         let map = MKMapView(frame: .zero)
@@ -110,6 +128,10 @@ struct MapViewRepresentable: UIViewRepresentable {
         map.delegate = context.coordinator
         let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
         map.addGestureRecognizer(tap)
+        let long = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
+        map.addGestureRecognizer(long)
+        context.coordinator.mapView = map
+        context.coordinator.updateForCurrentState()
         if let mbURL = Bundle.module.url(forResource: "basemap", withExtension: "mbtiles"),
            let overlay = MBTilesOverlay(mbtilesURL: mbURL) {
             map.addOverlay(overlay, level: .aboveLabels)
@@ -123,6 +145,9 @@ struct MapViewRepresentable: UIViewRepresentable {
         map.removeOverlays(current)
         map.addOverlays(airspaceManager.displayOverlays)
 
+        context.coordinator.mapView = map
+        context.coordinator.updateForCurrentState()
+
         if !context.coordinator.regionSet,
            let loc = locationManager.lastLocation {
             let meters = 40.0 * 1852.0
@@ -135,7 +160,12 @@ struct MapViewRepresentable: UIViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(airspaceManager: airspaceManager, settings: settings, viewModel: hudViewModel)
+        Coordinator(airspaceManager: airspaceManager,
+                    settings: settings,
+                    viewModel: hudViewModel,
+                    locationManager: locationManager,
+                    waypoint: $waypoint,
+                    navInfo: $navInfo)
     }
 
     class Coordinator: NSObject, MKMapViewDelegate {
@@ -143,19 +173,59 @@ struct MapViewRepresentable: UIViewRepresentable {
         private let airspaceManager: AirspaceManager
         private let settings: Settings
         private let viewModel: HUDViewModel
+        private let locationManager: LocationManager
+        private var cancellable: AnyCancellable?
+        var mapView: MKMapView?
         var regionSet = false
+        private var aircraft = MKPointAnnotation()
+        private var rangeLayer = CAShapeLayer()
+        private var trackLayer = CAShapeLayer()
+        private var targetOverlay: MKPolyline?
+        private var bannerAnnotation: MKPointAnnotation?
+        private var waypoint: Binding<Waypoint?>
+        private var navInfo: Binding<NavComputed?>
 
-        init(airspaceManager: AirspaceManager, settings: Settings, viewModel: HUDViewModel) {
+        init(airspaceManager: AirspaceManager,
+             settings: Settings,
+             viewModel: HUDViewModel,
+             locationManager: LocationManager,
+             waypoint: Binding<Waypoint?>,
+             navInfo: Binding<NavComputed?>) {
             self.airspaceManager = airspaceManager
             self.settings = settings
             self.viewModel = viewModel
+            self.locationManager = locationManager
+            self.waypoint = waypoint
+            self.navInfo = navInfo
+            super.init()
+
+            cancellable = locationManager.$lastLocation
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] loc in
+                    self?.updateAircraftLocation(loc)
+                }
         }
 
         @objc func handleTap(_ sender: UITapGestureRecognizer) {
             let mapView = sender.view as! MKMapView
             let point = sender.location(in: mapView)
             let coord = mapView.convert(point, toCoordinateFrom: mapView)
-            viewModel.onMapTap(coord)
+            if viewModel.zoneQueryOn {
+                viewModel.onMapTap(coord)
+            } else {
+                waypoint.wrappedValue = Waypoint(coordinate: coord)
+                updateNav()
+            }
+        }
+
+        @objc func handleLongPress(_ sender: UILongPressGestureRecognizer) {
+            if sender.state == .began {
+                waypoint.wrappedValue = nil
+                navInfo.wrappedValue = nil
+                if let overlay = targetOverlay { mapView?.removeOverlay(overlay) }
+                if let ann = bannerAnnotation { mapView?.removeAnnotation(ann) }
+            }
         }
 
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
@@ -224,6 +294,36 @@ struct MapViewRepresentable: UIViewRepresentable {
                 return nil
             }
 
+            if annotation === aircraft {
+                let id = "aircraft"
+                let view = mapView.dequeueReusableAnnotationView(withIdentifier: id) ?? MKAnnotationView(annotation: annotation, reuseIdentifier: id)
+                view.image = UIImage(systemName: "airplane")
+                view.bounds.size = CGSize(width: 30, height: 30)
+                if let hdg = locationManager.lastLocation?.course {
+                    view.transform = CGAffineTransform(rotationAngle: CGFloat(hdg * .pi / 180))
+                }
+                return view
+            }
+
+            if annotation === bannerAnnotation {
+                let id = "banner"
+                let view = mapView.dequeueReusableAnnotationView(withIdentifier: id) ?? MKAnnotationView(annotation: annotation, reuseIdentifier: id)
+                if let nav = navInfo.wrappedValue {
+                    let label = UILabel()
+                    label.numberOfLines = 0
+                    label.font = UIFont.monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+                    let fmt = DateFormatter()
+                    fmt.dateFormat = "HH:mm:ss"
+                    label.text = String(format: "BRG %03.0f\nDST %.1f\nETE %.0f\nETA %@", nav.bearing, nav.distance, nav.ete, fmt.string(from: nav.eta))
+                    label.textColor = .white
+                    label.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+                    label.sizeToFit()
+                    view.addSubview(label)
+                    view.bounds = label.bounds
+                }
+                return view
+            }
+
             let id = "info"
             let view = mapView.dequeueReusableAnnotationView(withIdentifier: id) ?? MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: id)
             view.canShowCallout = true
@@ -232,6 +332,7 @@ struct MapViewRepresentable: UIViewRepresentable {
 
         func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
             airspaceManager.updateMapRect(mapView.visibleMapRect)
+            updateLayers()
         }
 
         private func formattedProps(_ props: [String: Any]) -> String {
@@ -240,5 +341,137 @@ struct MapViewRepresentable: UIViewRepresentable {
             let items = filtered.prefix(3).map { "\($0.key): \($0.value)" }
             return items.joined(separator: "\n")
         }
+
+        private func updateLayers() {
+            guard let mapView else { return }
+            mapView.layer.sublayers?.removeAll { $0 === rangeLayer || $0 === trackLayer }
+            mapView.layer.addSublayer(rangeLayer)
+            mapView.layer.addSublayer(trackLayer)
+
+            guard let loc = locationManager.lastLocation else { return }
+            let center = mapView.convert(loc.coordinate, toPointTo: mapView)
+            let rangeNm = 10.0
+            let edge = GeodesicCalculator.destinationPoint(from: loc.coordinate, courseDeg: 90, distanceNm: rangeNm)
+            let edgePt = mapView.convert(edge, toPointTo: mapView)
+            let radius = hypot(edgePt.x - center.x, edgePt.y - center.y)
+            let ringPath = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: .pi*2, clockwise: true)
+            rangeLayer.fillColor = UIColor.clear.cgColor
+            rangeLayer.strokeColor = UIColor.orange.cgColor
+            rangeLayer.lineWidth = 1
+            rangeLayer.path = ringPath.cgPath
+
+            let vecDest = GeodesicCalculator.destinationPoint(from: loc.coordinate, courseDeg: loc.course, distanceNm: 1)
+            let vecPt = mapView.convert(vecDest, toPointTo: mapView)
+            let vecPath = UIBezierPath()
+            vecPath.move(to: center)
+            vecPath.addLine(to: vecPt)
+            trackLayer.strokeColor = UIColor.yellow.cgColor
+            trackLayer.lineWidth = 2
+            trackLayer.path = vecPath.cgPath
+        }
+
+        private func updateAircraftLocation(_ loc: CLLocation) {
+            aircraft.coordinate = loc.coordinate
+            mapView?.addAnnotation(aircraft)
+            updateLayers()
+            updateNav()
+        }
+
+        private func updateNav() {
+            guard let wp = waypoint.wrappedValue,
+                  let mapView else { return }
+            let state = AircraftState(position: aircraft.coordinate,
+                                     groundTrack: locationManager.lastLocation?.course ?? 0,
+                                     groundSpeedKt: max(0, locationManager.lastLocation?.speed ?? 0 * 1.94384),
+                                     altitudeFt: locationManager.rawGpsAltitude,
+                                     timestamp: Date())
+            let bd = GeodesicCalculator.bearingDistance(from: state.position, to: wp.coordinate)
+            let ete = state.groundSpeedKt > 0 ? bd.distance / state.groundSpeedKt * 3600 : 0
+            let eta = Date().addingTimeInterval(ete)
+            let ten = GeodesicCalculator.tenMinPoint(state: state)
+            navInfo.wrappedValue = NavComputed(bearing: bd.bearing, distance: bd.distance, ete: ete, eta: eta, tenMinPoint: ten)
+
+            if let old = targetOverlay { mapView.removeOverlay(old) }
+            var coords = [state.position, wp.coordinate]
+            let poly = MKPolyline(coordinates: &coords, count: 2)
+            targetOverlay = poly
+            mapView.addOverlay(poly)
+
+            let mid = GeodesicCalculator.destinationPoint(from: state.position, courseDeg: bd.bearing, distanceNm: bd.distance/2)
+            if let ann = bannerAnnotation { mapView.removeAnnotation(ann) }
+            let ann = MKPointAnnotation()
+            ann.coordinate = mid
+            bannerAnnotation = ann
+            mapView.addAnnotation(ann)
+        }
+
+        func updateForCurrentState() {
+            if let loc = locationManager.lastLocation {
+                updateAircraftLocation(loc)
+            }
+        }
+    }
+}
+
+struct TargetBannerView: View {
+    let nav: NavComputed
+
+    private var etaText: String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "HH:mm:ss"
+        return fmt.string(from: nav.eta)
+    }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(String(format: "BRG %03.0f°", nav.bearing))
+            Text(String(format: "DST %.1f NM", nav.distance))
+            Text(String(format: "ETE %.0f s", nav.ete))
+            Text("ETA \(etaText)")
+        }
+        .font(.caption2.monospacedDigit())
+        .padding(6)
+        .background(Color.black.opacity(0.6))
+        .foregroundColor(.white)
+        .cornerRadius(6)
+    }
+}
+
+struct StatusRibbonView: View {
+    @ObservedObject var locationManager: LocationManager
+    @State private var useMetric = false
+
+    private var gsText: String {
+        if useMetric {
+            return String(format: "%.1f km/h", max(0, (locationManager.lastLocation?.speed ?? 0) * 3.6))
+        } else {
+            return String(format: "%.1f kt", max(0, (locationManager.lastLocation?.speed ?? 0) * 1.94384))
+        }
+    }
+
+    private var altText: String {
+        if useMetric {
+            return String(format: "%.0f m", locationManager.rawGpsAltitude * 0.3048)
+        } else {
+            return String(format: "%.0f ft", locationManager.rawGpsAltitude)
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 20) {
+            if let track = locationManager.lastLocation?.course, track >= 0 {
+                Text(String(format: "TRK %.0f°", track))
+            } else {
+                Text("TRK --")
+            }
+            Text("GS \(gsText)")
+            Text("ALT \(altText)")
+        }
+        .font(.caption.monospacedDigit())
+        .padding(6)
+        .background(Color.black.opacity(0.6))
+        .foregroundColor(.white)
+        .cornerRadius(6)
+        .onTapGesture { useMetric.toggle() }
     }
 }

--- a/GPS Logger/Navigation/GeodesicCalculator.swift
+++ b/GPS Logger/Navigation/GeodesicCalculator.swift
@@ -1,0 +1,47 @@
+import Foundation
+import CoreLocation
+
+/// 大圏計算を行うユーティリティ
+enum GeodesicCalculator {
+    /// 2点間の初期方位(真方位)と距離(NM)を求める
+    static func bearingDistance(from: CLLocationCoordinate2D,
+                                to: CLLocationCoordinate2D) -> (bearing: Double, distance: Double) {
+        let lat1 = from.latitude * .pi / 180
+        let lon1 = from.longitude * .pi / 180
+        let lat2 = to.latitude * .pi / 180
+        let lon2 = to.longitude * .pi / 180
+        let dLon = lon2 - lon1
+        let y = sin(dLon) * cos(lat2)
+        let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+        var bearing = atan2(y, x) * 180 / .pi
+        if bearing < 0 { bearing += 360 }
+        let r = 6371.0 // km
+        let d = acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(dLon)) * r
+        let nm = d / 1.852
+        return (bearing, nm)
+    }
+
+    /// 始点から方位と距離で終点を求める
+    static func destinationPoint(from: CLLocationCoordinate2D,
+                                 courseDeg: Double,
+                                 distanceNm: Double) -> CLLocationCoordinate2D {
+        let distRad = (distanceNm * 1.852) / 6371.0
+        let brg = courseDeg * .pi / 180
+        let lat1 = from.latitude * .pi / 180
+        let lon1 = from.longitude * .pi / 180
+        let lat2 = asin(sin(lat1) * cos(distRad) + cos(lat1) * sin(distRad) * cos(brg))
+        let lon2 = lon1 + atan2(sin(brg) * sin(distRad) * cos(lat1),
+                                cos(distRad) - sin(lat1) * sin(lat2))
+        let latDeg = lat2 * 180 / .pi
+        var lonDeg = lon2 * 180 / .pi
+        if lonDeg > 180 { lonDeg -= 360 }
+        if lonDeg < -180 { lonDeg += 360 }
+        return CLLocationCoordinate2D(latitude: latDeg, longitude: lonDeg)
+    }
+
+    /// 与えられた自機状態から10分後の予測位置を求める
+    static func tenMinPoint(state: AircraftState) -> CLLocationCoordinate2D {
+        let dist = state.groundSpeedKt * (10.0 / 60.0)
+        return destinationPoint(from: state.position, courseDeg: state.groundTrack, distanceNm: dist)
+    }
+}

--- a/GPS Logger/Navigation/NavModels.swift
+++ b/GPS Logger/Navigation/NavModels.swift
@@ -1,0 +1,39 @@
+import Foundation
+import CoreLocation
+
+/// 自機の現在状態を表すモデル
+struct AircraftState {
+    /// 位置
+    var position: CLLocationCoordinate2D
+    /// グランドトラック (真方位)
+    var groundTrack: Double
+    /// グランドスピード (kt)
+    var groundSpeedKt: Double
+    /// 高度 (ft)
+    var altitudeFt: Double
+    /// 計測時刻
+    var timestamp: Date
+}
+
+/// マップ上の目標地点
+struct Waypoint: Identifiable {
+    let id = UUID()
+    /// 座標
+    var coordinate: CLLocationCoordinate2D
+    /// 任意名称
+    var name: String = "WP"
+}
+
+/// 航法計算結果
+struct NavComputed {
+    /// 目的地への真方位方位
+    var bearing: Double
+    /// 目的地までの距離 (NM)
+    var distance: Double
+    /// 到達までの予想到達時間 (秒)
+    var ete: TimeInterval
+    /// 予想到達時刻
+    var eta: Date
+    /// 10 分後の予測位置
+    var tenMinPoint: CLLocationCoordinate2D
+}


### PR DESCRIPTION
## Summary
- add `AircraftState`, `Waypoint`, `NavComputed` models
- implement `GeodesicCalculator` with bearing/distance and ten minute point
- extend map view to draw aircraft symbol, ground track vector, range ring and waypoint line
- show target banner and status ribbon with nav data

## Testing
- `swift build` *(fails: unable to access github.com)*
- `swiftformat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848416c66388326a32594f9af53ddf5