### PR TITLE
Add range ring radius setting and theme toggle

### DIFF
--- a/GPS Logger/Assets.xcassets/RangeRingDay.colorset/Contents.json
+++ b/GPS Logger/Assets.xcassets/RangeRingDay.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.0",
+          "green" : "0.647",
+          "blue" : "0.0",
+          "alpha" : "1.0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GPS Logger/Assets.xcassets/RangeRingNight.colorset/Contents.json
+++ b/GPS Logger/Assets.xcassets/RangeRingNight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0",
+          "green" : "1.0",
+          "blue" : "1.0",
+          "alpha" : "1.0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GPS Logger/Assets.xcassets/TrackDay.colorset/Contents.json
+++ b/GPS Logger/Assets.xcassets/TrackDay.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.0",
+          "green" : "1.0",
+          "blue" : "0.0",
+          "alpha" : "1.0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GPS Logger/Assets.xcassets/TrackNight.colorset/Contents.json
+++ b/GPS Logger/Assets.xcassets/TrackNight.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.0",
+          "green" : "1.0",
+          "blue" : "0.0",
+          "alpha" : "1.0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -53,6 +53,12 @@ final class Settings: ObservableObject {
     // Mach/CAS calculation option
     @UserDefaultBacked(key: "enableMachCalculation") var enableMachCalculation: Bool = true
 
+    /// レンジリングの半径 (NM)
+    @UserDefaultBacked(key: "rangeRingRadiusNm") var rangeRingRadiusNm: Double = 10.0
+
+    /// Night テーマを使用するかどうか
+    @UserDefaultBacked(key: "useNightTheme") var useNightTheme: Bool = false
+
     init() {
         $processNoise
             .sink { [weak self] _ in self?.objectWillChange.send() }
@@ -163,6 +169,14 @@ final class Settings: ObservableObject {
             .store(in: &cancellables)
 
         $enableMachCalculation
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $rangeRingRadiusNm
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $useNightTheme
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## Summary
- add range ring radius and day/night theme flags to `Settings`
- subscribe to new settings in `MainMapView` and handle pinch gesture to change radius
- draw range ring and track lines using theme colors
- provide color assets for day/night styles

## Testing
- `swift test` *(fails: unable to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_68484410f5b48326926525936ec3610d