### PR TITLE
Add geodesic and map interaction tests

### DIFF
--- a/GPS LoggerTests/GeodesicCalculatorTests.swift
+++ b/GPS LoggerTests/GeodesicCalculatorTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import CoreLocation
+@testable import GPS_Logger
+
+final class GeodesicCalculatorTests: XCTestCase {
+    func testBearingDistance() {
+        let from = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let to = CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        let result = GeodesicCalculator.bearingDistance(from: from, to: to)
+        XCTAssertEqual(result.bearing, 44.996, accuracy: 0.01)
+        XCTAssertEqual(result.distance, 84.908, accuracy: 0.01)
+    }
+
+    func testDestinationPoint() {
+        let start = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let dest = GeodesicCalculator.destinationPoint(from: start, courseDeg: 90, distanceNm: 60)
+        XCTAssertEqual(dest.latitude, 0, accuracy: 0.0001)
+        XCTAssertEqual(dest.longitude, 1.0, accuracy: 0.01)
+    }
+
+    func testETAComputation() {
+        let from = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let to = CLLocationCoordinate2D(latitude: 0, longitude: 0.5)
+        let bd = GeodesicCalculator.bearingDistance(from: from, to: to)
+        XCTAssertEqual(bd.bearing, 90, accuracy: 0.01)
+        XCTAssertEqual(bd.distance, 30.02, accuracy: 0.01)
+        let speed = 120.0
+        let ete = bd.distance / speed * 3600
+        XCTAssertEqual(ete, 900.6, accuracy: 0.5)
+        let now = Date()
+        let eta = now.addingTimeInterval(ete)
+        XCTAssertEqual(eta.timeIntervalSince(now), ete, accuracy: 0.5)
+    }
+
+    func testTenMinutePoint() {
+        let state = AircraftState(position: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                                  groundTrack: 90,
+                                  groundSpeedKt: 120,
+                                  altitudeFt: 0,
+                                  timestamp: Date())
+        let point = GeodesicCalculator.tenMinPoint(state: state)
+        XCTAssertEqual(point.latitude, 0, accuracy: 0.0001)
+        XCTAssertEqual(point.longitude, 0.333, accuracy: 0.001)
+    }
+}

--- a/GPS LoggerTests/MainMapViewInteractionTests.swift
+++ b/GPS LoggerTests/MainMapViewInteractionTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import MapKit
+import SwiftUI
+@testable import GPS_Logger
+
+final class MainMapViewInteractionTests: XCTestCase {
+    // MKMapView で座標変換結果を固定するためのモック
+    final class MockMapView: MKMapView {
+        var forcedCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        override func convert(_ point: CGPoint, toCoordinateFrom view: UIView?) -> CLLocationCoordinate2D {
+            forcedCoordinate
+        }
+    }
+
+    // タップ位置を固定するモック
+    final class MockTapGesture: UITapGestureRecognizer {
+        var point = CGPoint.zero
+        override func location(in view: UIView?) -> CGPoint { point }
+    }
+
+    /// テスト用 Coordinator を生成
+    private func makeCoordinator(waypoint: Binding<Waypoint?>, navInfo: Binding<NavComputed?>) -> (MapViewRepresentable.Coordinator, LocationManager, MockMapView) {
+        let settings = Settings()
+        let flm = FlightLogManager(settings: settings)
+        let alt = AltitudeFusionManager(settings: settings)
+        let loc = LocationManager(flightLogManager: flm, altitudeFusionManager: alt, settings: settings)
+        let air = AirspaceManager(settings: settings)
+        let hud = HUDViewModel(airspaceManager: air)
+        let repr = MapViewRepresentable(locationManager: loc, airspaceManager: air, settings: settings, hudViewModel: hud, waypoint: waypoint, navInfo: navInfo)
+        let coord = repr.makeCoordinator()
+        let map = MockMapView()
+        coord.mapView = map
+        return (coord, loc, map)
+    }
+
+    func testHandleTapCreatesWaypoint() {
+        var wp: Waypoint?
+        var nav: NavComputed?
+        let bindingWp = Binding<Waypoint?>(get: { wp }, set: { wp = $0 })
+        let bindingNav = Binding<NavComputed?>(get: { nav }, set: { nav = $0 })
+        let (coord, _, map) = makeCoordinator(waypoint: bindingWp, navInfo: bindingNav)
+        map.forcedCoordinate = CLLocationCoordinate2D(latitude: 1, longitude: 2)
+        let tap = MockTapGesture()
+        tap.view = map
+        coord.handleTap(tap)
+        XCTAssertEqual(wp?.coordinate.latitude, 1, accuracy: 0.0001)
+        XCTAssertEqual(wp?.coordinate.longitude, 2, accuracy: 0.0001)
+    }
+
+    func testRangeRingUpdated() {
+        var wp: Waypoint?
+        var nav: NavComputed?
+        let bwp = Binding<Waypoint?>(get: { wp }, set: { wp = $0 })
+        let bnav = Binding<NavComputed?>(get: { nav }, set: { nav = $0 })
+        let (coord, loc, map) = makeCoordinator(waypoint: bwp, navInfo: bnav)
+        let location = CLLocation(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0), altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5, course: 90, speed: 100/1.94384, timestamp: Date())
+        loc.lastLocation = location
+        coord.updateForCurrentState()
+        let hasLayer = map.layer.sublayers?.contains { $0 is CAShapeLayer } ?? false
+        XCTAssertTrue(hasLayer)
+    }
+}


### PR DESCRIPTION
## Summary
- add `GeodesicCalculatorTests` for bearing, distance, ETA and 10 minute point
- add `MainMapViewInteractionTests` validating tap handling and range ring update

## Testing
- `swift test -l` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_684849fd916c832697325c4b20dcbf48