### PR TITLE
Add track-up map and fixed range behavior

### DIFF
--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -53,6 +53,9 @@ final class Settings: ObservableObject {
     // Mach/CAS calculation option
     @UserDefaultBacked(key: "enableMachCalculation") var enableMachCalculation: Bool = true
 
+    /// 使用可能なレンジ段階 (レンジリング半径)
+    static let rangeLevelsNm: [Double] = [2.5, 5, 10, 20, 40, 80, 160]
+
     /// レンジリングの半径 (NM)
     @UserDefaultBacked(key: "rangeRingRadiusNm") var rangeRingRadiusNm: Double = 10.0
 


### PR DESCRIPTION
## Summary
- add discrete range levels to `Settings`
- update `MainMapView` to support track-up rotation, free-scroll toggle and multiple range rings
- show current range and free scroll status on screen
- display TRK/GS/ALT text below the ownship symbol

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git)*
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_68485770ab248326908c8787b1cf1b8b