### PR TITLE
Reduce CPU load from altitude updates

### DIFF
--- a/GPS Logger/ContentView.swift
+++ b/GPS Logger/ContentView.swift
@@ -566,7 +566,6 @@ private struct NavigationContentView: View {
             .onAppear {
                 UIApplication.shared.isIdleTimerDisabled = true
                 locationManager.startUpdatingForDisplay()
-                altitudeFusionManager.startUpdates(gpsAltitude: nil)
             }
             .onReceive(uiUpdateTimer) { _ in
                 currentTime = Date()


### PR DESCRIPTION
## Summary
- avoid starting altitude sensors multiple times
- throttle and move sensor updates off the main queue
- remove unused altitude start on main view

## Testing
- `swift test --enable-test-discovery` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68485af561588326907920d8a9dd7432