### PR TITLE
Map updates limited to GPS updates

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -465,8 +465,6 @@ struct MapViewRepresentable: UIViewRepresentable {
             trackLayer.strokeColor = UIColor(hex: trackHex)?.cgColor ?? UIColor.yellow.cgColor
             trackLayer.lineWidth = 2
             trackLayer.path = vecPath.cgPath
-
-            updateCamera()
         }
 
         private func updateCamera() {
@@ -496,6 +494,7 @@ struct MapViewRepresentable: UIViewRepresentable {
             }
             updateLayers()
             updateNav()
+            updateCamera()
         }
 
         private func updateNav() {


### PR DESCRIPTION
## Summary
- avoid calling `updateCamera()` on every map region change
- update the camera only when the GPS location changes

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8c99ee48326b4b314b65f6c697a