### PR TITLE
Fix map interaction for locked mode

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -158,6 +158,8 @@ struct MapViewRepresentable: UIViewRepresentable {
         let map = MKMapView(frame: .zero)
         map.showsUserLocation = true
         map.delegate = context.coordinator
+        map.isZoomEnabled = false
+        map.isScrollEnabled = freeScroll
         let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
         map.addGestureRecognizer(tap)
         let long = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
@@ -179,6 +181,8 @@ struct MapViewRepresentable: UIViewRepresentable {
         let current = map.overlays.filter { !($0 is MBTilesOverlay) }
         map.removeOverlays(current)
         map.addOverlays(airspaceManager.displayOverlays)
+
+        map.isScrollEnabled = freeScroll
 
         context.coordinator.mapView = map
         context.coordinator.updateForCurrentState()


### PR DESCRIPTION
## Summary
- disable panning when not in free scroll
- update map scroll setting when view updates
- rely on custom pinch for zoom

## Testing
- `swift test` *(fails: failed to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6848af08a0cc832688121a6c899e63e7