### PR TITLE
Fix build errors in HUDViewModel and MapView

### DIFF
--- a/GPS Logger/Airspace/HUDViewModel.swift
+++ b/GPS Logger/Airspace/HUDViewModel.swift
@@ -109,7 +109,7 @@ final class HUDViewModel: ObservableObject, AirspaceSlimBuilder {
     func onMapTap(_ coord: CLLocationCoordinate2D) {
         Logger.airspace.debug("HUD map tap lat=\(String(format: "%.4f", coord.latitude)) lon=\(String(format: "%.4f", coord.longitude))")
         guard zoneQueryOn else { return }
-        let hit = tree.search(point: coord)
+        var hit = tree.search(point: coord)
         hit.sort { a, b in
             if alt_m(a.upper) != alt_m(b.upper) {
                 return alt_m(a.upper) > alt_m(b.upper)

--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -339,33 +339,6 @@ struct MapViewRepresentable: UIViewRepresentable {
             return MKOverlayRenderer(overlay: overlay)
         }
 
-        @available(iOS 17.0, *)
-        func mapView(_ mapView: MKMapView, didSelect overlay: MKOverlay) {
-            guard let shape = overlay as? MKShape,
-                  let title = shape.title else { return }
-            let rect = overlay.boundingMapRect
-            let coord = CLLocationCoordinate2D(latitude: rect.midY, longitude: rect.midX)
-            let ann = MKPointAnnotation()
-            ann.coordinate = coord
-            ann.title = title
-            if let f = overlay as? FeaturePolyline {
-                ann.subtitle = formattedProps(f.properties)
-            } else if let f = overlay as? FeaturePolygon {
-                ann.subtitle = formattedProps(f.properties)
-            } else if let f = overlay as? FeatureCircle {
-                ann.subtitle = formattedProps(f.properties)
-            }
-            infoAnnotation = ann
-            mapView.addAnnotation(ann)
-        }
-
-        @available(iOS 17.0, *)
-        func mapView(_ mapView: MKMapView, didDeselect overlay: MKOverlay) {
-            if let ann = infoAnnotation {
-                mapView.removeAnnotation(ann)
-                infoAnnotation = nil
-            }
-        }
 
         func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
             if annotation is MKUserLocation {
@@ -551,6 +524,37 @@ struct MapViewRepresentable: UIViewRepresentable {
         }
     }
 }
+
+#if swift(>=5.9)
+@available(iOS 17.0, *)
+extension MapViewRepresentable.Coordinator {
+    func mapView(_ mapView: MKMapView, didSelect overlay: MKOverlay) {
+        guard let shape = overlay as? MKShape,
+              let title = shape.title else { return }
+        let rect = overlay.boundingMapRect
+        let coord = CLLocationCoordinate2D(latitude: rect.midY, longitude: rect.midX)
+        let ann = MKPointAnnotation()
+        ann.coordinate = coord
+        ann.title = title
+        if let f = overlay as? FeaturePolyline {
+            ann.subtitle = formattedProps(f.properties)
+        } else if let f = overlay as? FeaturePolygon {
+            ann.subtitle = formattedProps(f.properties)
+        } else if let f = overlay as? FeatureCircle {
+            ann.subtitle = formattedProps(f.properties)
+        }
+        infoAnnotation = ann
+        mapView.addAnnotation(ann)
+    }
+
+    func mapView(_ mapView: MKMapView, didDeselect overlay: MKOverlay) {
+        if let ann = infoAnnotation {
+            mapView.removeAnnotation(ann)
+            infoAnnotation = nil
+        }
+    }
+}
+#endif
 
 struct TargetBannerView: View {
     let nav: NavComputed


### PR DESCRIPTION
## Summary
- fix `hit` variable mutability in `HUDViewModel`
- move overlay delegate callbacks to conditional extension for iOS 17

## Testing
- `swift build` *(fails: failed to clone https://github.com/apple/swift-testing.git)*
- `swift test` *(fails: failed to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_684e171dd1e48326a57282c0e40a26d5