### PR TITLE
Fix metersForRng scope

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -2,6 +2,12 @@ import SwiftUI
 import MapKit
 import Combine
 
+/// 新しいズーム倍率（旧来の 4 倍）
+private func metersForRng(_ radiusNm: Double) -> Double {
+    let diameterNm = radiusNm * 4
+    return diameterNm * 2 * 1852.0
+}
+
 /// Map 表示を行うメインビュー
 struct MainMapView: View {
     @StateObject var settings: Settings
@@ -458,12 +464,6 @@ struct MapViewRepresentable: UIViewRepresentable {
             let work = DispatchWorkItem { [weak self] in self?.updateLayers() }
             pendingLayerWorkItem = work
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: work)
-        }
-
-        /// 新しいズーム倍率（旧来の 4 倍）
-        private func metersForRng(_ radiusNm: Double) -> Double {
-            let diameterNm = radiusNm * 4
-            return diameterNm * 2 * 1852.0
         }
 
         private func updateLayers() {


### PR DESCRIPTION
## Summary
- `metersForRng` をファイルレベル関数として定義し、`Coordinator` 内から削除
- 上記に伴い `updateUIView` と `applyZoom` から同関数を呼び出し可能に

## Testing
- `swift test -l` *(失敗: 依存パッケージ取得のためのネットワークアクセスが拒否されました)*

------
https://chatgpt.com/codex/tasks/task_e_684e3577ec248326bb63310adbb8549a