### PR TITLE
Fix MainActor isolation errors in logging

### DIFF
--- a/GPS Logger/FlightLogManager.swift
+++ b/GPS Logger/FlightLogManager.swift
@@ -121,7 +121,7 @@ final class FlightLogManager: ObservableObject {
     }
 
     /// Export all logs as CSV with UTF-8 BOM.
-    func exportCSV() -> URL? {
+    @MainActor func exportCSV() -> URL? {
         guard let folderURL = sessionFolderURL else { return nil }
         let fileName = "FlightLog_\(Int(Date().timeIntervalSince1970)).csv"
         let fileURL = folderURL.appendingPathComponent(fileName)
@@ -193,7 +193,7 @@ final class FlightLogManager: ObservableObject {
     }
 
     /// Export distance measurements as CSV with UTF-8 BOM.
-    func exportDistanceCSV() -> URL? {
+    @MainActor func exportDistanceCSV() -> URL? {
         guard let folderURL = sessionFolderURL else { return nil }
         let fileName = "Distance_\(Int(Date().timeIntervalSince1970)).csv"
         let fileURL = folderURL.appendingPathComponent(fileName)
@@ -226,7 +226,7 @@ final class FlightLogManager: ObservableObject {
     ///   - measurement: The measurement to export logs for.
     ///   - logs: Flight logs displayed in the distance graph.
     /// - Returns: URL of the exported CSV if successful.
-    func exportMeasurementLogs(for measurement: DistanceMeasurement,
+    @MainActor func exportMeasurementLogs(for measurement: DistanceMeasurement,
                                logs: [FlightLog]) -> URL? {
         guard let folderURL = sessionFolderURL else { return nil }
 
@@ -268,7 +268,7 @@ final class FlightLogManager: ObservableObject {
     ///   - measurement: The associated distance measurement.
     ///   - chartImage: Image created from `DistanceGraphView`.
     /// - Returns: URL of the saved PNG if successful.
-    func exportMeasurementGraphImage(for measurement: DistanceMeasurement,
+    @MainActor func exportMeasurementGraphImage(for measurement: DistanceMeasurement,
                                      chartImage: UIImage) -> URL? {
         guard let folderURL = sessionFolderURL else { return nil }
 

--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -102,7 +102,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         locationManager.pausesLocationUpdatesAutomatically = false
     }
 
-    func startRecording() {
+    @MainActor func startRecording() {
         flightLogManager.startSession()
         isRecording = true
 
@@ -119,25 +119,25 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
                                         repeats: true)
     }
 
-    @objc private func handleLogTimer() {
+    @MainActor @objc private func handleLogTimer() {
         recordLog()
     }
 
-    func stopRecording() {
+    @MainActor func stopRecording() {
         isRecording = false
         logTimer?.invalidate()
         logTimer = nil
         altitudeFusionManager.stopUpdates()
     }
 
-    func recordPhotoCapture() -> Int? {
+    @MainActor func recordPhotoCapture() -> Int? {
         if !isRecording { return nil }
         photoCounter += 1
         pendingPhotoIndex = photoCounter
         return photoCounter
     }
 
-    private func updateAltitude(with loc: CLLocation) {
+    @MainActor private func updateAltitude(with loc: CLLocation) {
         let altitudeFt = loc.altitude * 3.28084
         let ellipsoidFt = loc.ellipsoidalAltitude * 3.28084
         let now = Date()
@@ -159,7 +159,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         altitudeFusionManager.startUpdates(gpsAltitude: altitudeFt)
     }
 
-    func recordLog() {
+    @MainActor func recordLog() {
         guard let loc = lastLocation else { return }
         let altitudeFt = rawGpsAltitude
         let now = Date()


### PR DESCRIPTION
## Summary
- mark functions that access MainActor-bound state with `@MainActor`
  - `FlightLogManager` export helpers
  - `LocationManager` logging and recording helpers

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_685010c06d6883269f82d506cf628902