### PR TITLE
Fix actor isolation warnings

### DIFF
--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -45,6 +45,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
 
     private var cancellables = Set<AnyCancellable>()
 
+    @MainActor
     init(flightLogManager: FlightLogManager,
          altitudeFusionManager: AltitudeFusionManager,
          settings: Settings) {

--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -456,8 +456,10 @@ struct MapViewRepresentable: UIViewRepresentable {
             let dh = abs(rect.size.height - lastVisibleRect.size.height)
             let threshold = max(rect.size.width, rect.size.height) * 0.1
             if lastVisibleRect.isNull || dx > threshold || dy > threshold || dw > threshold || dh > threshold {
-                airspaceManager.updateMapRect(rect)
                 lastVisibleRect = rect
+                Task { @MainActor in
+                    airspaceManager.updateMapRect(rect)
+                }
             }
             scheduleUpdateLayers()
         }


### PR DESCRIPTION
## Summary
- mark `LocationManager` initializer as `@MainActor`
- schedule map region updates asynchronously to avoid publishing during view updates

## Testing
- `swift test -q` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685013335c288326bb6b69cbc98b0942