### PR TITLE
Fix overlay update race and actor isolation

### DIFF
--- a/GPS Logger/AltitudeFusionManager.swift
+++ b/GPS Logger/AltitudeFusionManager.swift
@@ -175,7 +175,7 @@ final class AltitudeFusionManager: ObservableObject {
     }
 
     /// 現在の基準高度と相対高度から計算される気圧高度(ft)
-    nonisolated var pressureAltitudeFt: Double? {
+    var pressureAltitudeFt: Double? {
         baselineAltitude.map { $0 + (relativeAltitude ?? 0) }
     }
 }

--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -180,7 +180,9 @@ struct MapViewRepresentable: UIViewRepresentable {
            let overlay = MBTilesOverlay(mbtilesURL: mbURL) {
             map.addOverlay(overlay, level: .aboveLabels)
         }
-        airspaceManager.updateMapRect(map.visibleMapRect)
+        DispatchQueue.main.async {
+            airspaceManager.updateMapRect(map.visibleMapRect)
+        }
         return map
     }
 


### PR DESCRIPTION
## Summary
- avoid publishing updates during view creation by dispatching updateMapRect
- mark `pressureAltitudeFt` as a regular property to respect main actor isolation

## Testing
- `swift test --enable-test-discovery` *(fails: unable to clone swift-testing)*

------
https://chatgpt.com/codex/tasks/task_e_685014b8bf04832685ae67053b9dc1ad