### PR TITLE
Fix access for Settings in LegSummary

### DIFF
--- a/GPS Logger/FlightAssistView.swift
+++ b/GPS Logger/FlightAssistView.swift
@@ -66,6 +66,7 @@ struct FlightAssistView: View {
         let ciSpeed: Double
         let duration: TimeInterval
 
+        @MainActor
         func isStable(using settings: Settings) -> Bool {
             duration >= settings.faStableDuration &&
             ciTrack <= settings.faTrackCILimit &&


### PR DESCRIPTION
## Summary
- mark `LegSummary.isStable(using:)` with `@MainActor` to safely access actor-isolated `Settings`

## Testing
- `swift test` *(fails: unable to fetch dependency)*

------
https://chatgpt.com/codex/tasks/task_e_685015b7b7f483269b027f2af487dba9