### PR TITLE
Fix orientation crash

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -276,7 +276,7 @@ struct MapViewRepresentable: UIViewRepresentable {
                 .sink { [weak self] _ in self?.scheduleUpdateLayers() }
                 .store(in: &settingsCancellables)
 
-            settings.$orientationMode
+            settings.$orientationModeValue
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in self?.updateCamera() }
                 .store(in: &settingsCancellables)

--- a/GPS Logger/Map/MapLayerSettingsView.swift
+++ b/GPS Logger/Map/MapLayerSettingsView.swift
@@ -8,7 +8,10 @@ struct MapLayerSettingsView: View {
 
     var body: some View {
         Form {
-            Picker("Orientation", selection: $settings.orientationMode) {
+            Picker("Orientation", selection: Binding(
+                get: { settings.orientationMode },
+                set: { settings.orientationMode = $0 }
+            )) {
                 ForEach(Settings.MapOrientationMode.allCases) { mode in
                     Text(mode.label).tag(mode)
                 }

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -67,7 +67,11 @@ final class Settings: ObservableObject {
         }
     }
 
-    @UserDefaultBacked(key: "orientationMode") var orientationMode: MapOrientationMode = .trackUp
+    @UserDefaultBacked(key: "orientationMode") var orientationModeValue: String = MapOrientationMode.trackUp.rawValue
+    var orientationMode: MapOrientationMode {
+        get { MapOrientationMode(rawValue: orientationModeValue) ?? .trackUp }
+        set { orientationModeValue = newValue.rawValue }
+    }
 
     /// ズーム可能な正方形サイズ (一辺) を NM で定義
     static let zoomDiametersNm: [Double] = [5, 10, 20, 40, 80, 160, 320]
@@ -232,7 +236,7 @@ final class Settings: ObservableObject {
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
 
-        $orientationMode
+        $orientationModeValue
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary
- fix crash when changing map orientation by storing enum raw value
- update map layer settings picker binding
- watch raw orientation value for updates

## Testing
- `swift test` *(fails: failed to clone repository)*

------
https://chatgpt.com/codex/tasks/task_e_6850192b4be88326b71e5b1cc24f37d1