### PR TITLE
Increase GPS alert border

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -52,7 +52,7 @@ struct MainMapView: View {
                     .ignoresSafeArea()
 
                 Rectangle()
-                    .stroke(Color.red, lineWidth: 4)
+                    .stroke(Color.red, lineWidth: 20)
                     .opacity(gpsAlert ? 1.0 : 0.0)
                     .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: gpsAlert)
                     .ignoresSafeArea()


### PR DESCRIPTION
## Summary
- enlarge the red border in the map view that warns when GPS is not received

## Testing
- `swift test --disable-sandbox` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6856ad408adc83269e804b691ef25666