### PR TITLE
Fix actor isolation warning in overlay renderer

### DIFF
--- a/GPS Logger/Map/TrackVectorOverlay.swift
+++ b/GPS Logger/Map/TrackVectorOverlay.swift
@@ -26,6 +26,7 @@ final class TrackVectorOverlay: NSObject, MKOverlay {
     }
 }
 
+@MainActor
 final class TrackVectorRenderer: MKOverlayRenderer {
     private let overlayObj: TrackVectorOverlay
     private let settings: Settings
@@ -41,7 +42,7 @@ final class TrackVectorRenderer: MKOverlayRenderer {
         let centerPt = point(for: MKMapPoint(overlayObj.coordinate))
         let dest = GeodesicCalculator.destinationPoint(from: overlayObj.coordinate, courseDeg: overlayObj.courseDeg, distanceNm: overlayObj.radiusNm)
         let destPt = point(for: MKMapPoint(dest))
-        var path = CGMutablePath()
+        let path = CGMutablePath()
         path.move(to: centerPt)
         path.addLine(to: destPt)
 


### PR DESCRIPTION
## Summary
- mark `TrackVectorRenderer` as `@MainActor` to access `Settings` properties safely
- change `path` to a constant

## Testing
- `swift test -v` *(fails: unable to clone https://github.com/apple/swift-testing.git)*

------
https://chatgpt.com/codex/tasks/task_e_6857e749da448326ac5b0a09f0315fe1