### PR TITLE
Fix actor isolation for RangeRingRenderer

### DIFF
--- a/GPS Logger/Map/RangeRingOverlay.swift
+++ b/GPS Logger/Map/RangeRingOverlay.swift
@@ -22,6 +22,7 @@ final class RangeRingOverlay: NSObject, MKOverlay {
     }
 }
 
+@MainActor
 final class RangeRingRenderer: MKOverlayRenderer {
     private let overlayObj: RangeRingOverlay
     private let settings: Settings


### PR DESCRIPTION
## Summary
- mark `RangeRingRenderer` as `@MainActor`

## Testing
- `swift test --parallel --enable-code-coverage` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6857e81874808326a0f7da67eafcb92e