### PR TITLE
Use Geomagnetism fallback for magnetic variation

### DIFF
--- a/GPS Logger/MagneticVariation.swift
+++ b/GPS Logger/MagneticVariation.swift
@@ -38,7 +38,21 @@ struct MagneticVariation {
                 value = model.declination(atLatitude: coordinate.latitude,
                                           longitude: coordinate.longitude,
                                           altitude: 0)
+            } else {
+                // CLGeomagneticModel が利用できない場合は独自計算を行う
+                let geo = Geomagnetism(longitude: coordinate.longitude,
+                                       latitude: coordinate.latitude,
+                                       altitude: 0,
+                                       date: date)
+                value = geo.declination
             }
+        } else {
+            // iOS 16 未満では Geomagnetism を使って算出
+            let geo = Geomagnetism(longitude: coordinate.longitude,
+                                   latitude: coordinate.latitude,
+                                   altitude: 0,
+                                   date: date)
+            value = geo.declination
         }
         cachedCoordinate = coordinate
         cachedDate = date


### PR DESCRIPTION
## Summary
- fall back to the `Geomagnetism` class in `MagneticVariation` when `CLGeomagneticModel` can't be used

## Testing
- `swift test` *(fails: unable to clone swift-testing due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6858754147a4832682550808b3921ac4