### PR TITLE
Add radial display for overlay selection

### DIFF
--- a/GPS Logger/Navigation/NavModels.swift
+++ b/GPS Logger/Navigation/NavModels.swift
@@ -28,6 +28,8 @@ struct Waypoint: Identifiable {
 struct NavComputed {
     /// 目的地への真方位方位
     var bearing: Double
+    /// 受信局から見たラジアル(真方位)
+    var radial: Double?
     /// 目的地までの距離 (NM)
     var distance: Double
     /// 到達までの予想到達時間 (秒)


### PR DESCRIPTION
## Summary
- extend `NavComputed` with optional `radial`
- show magnetic radial and DME in `TargetBannerView`
- compute radial and navigation info when overlays are selected
- position overlay annotation near top of map and clear nav info on deselect

## Testing
- `swift test -q` *(fails: unable to access github.com)*
- `swift build -q` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_685907d64cf4832681f08e26472cf746