### PR TITLE
Remove CLGeomagneticModel usage

### DIFF
--- a/GPS Logger/MagneticVariation.swift
+++ b/GPS Logger/MagneticVariation.swift
@@ -32,28 +32,12 @@ struct MagneticVariation {
             }
         }
 
-        var value: Double = 0
-        if #available(iOS 16.0, macOS 13.0, *) {
-            if let model = CLGeomagneticModel(date: date) {
-                value = model.declination(atLatitude: coordinate.latitude,
-                                          longitude: coordinate.longitude,
-                                          altitude: 0)
-            } else {
-                // CLGeomagneticModel が利用できない場合は独自計算を行う
-                let geo = Geomagnetism(longitude: coordinate.longitude,
-                                       latitude: coordinate.latitude,
-                                       altitude: 0,
-                                       date: date)
-                value = geo.declination
-            }
-        } else {
-            // iOS 16 未満では Geomagnetism を使って算出
-            let geo = Geomagnetism(longitude: coordinate.longitude,
-                                   latitude: coordinate.latitude,
-                                   altitude: 0,
-                                   date: date)
-            value = geo.declination
-        }
+        // Geomagnetism を使って磁気偏差を算出
+        let geo = Geomagnetism(longitude: coordinate.longitude,
+                               latitude: coordinate.latitude,
+                               altitude: 0,
+                               date: date)
+        let value = geo.declination
         cachedCoordinate = coordinate
         cachedDate = date
         cachedValue = value

--- a/GPS LoggerTests/GeomagnetismTests.swift
+++ b/GPS LoggerTests/GeomagnetismTests.swift
@@ -18,16 +18,6 @@ final class GeomagnetismTests: XCTestCase {
                                    latitude: coord.latitude,
                                    altitude: 0,
                                    date: date)
-            #if canImport(CoreLocation)
-            if #available(iOS 16.0, macOS 13.0, *),
-               let model = CLGeomagneticModel(date: date) {
-                let result = model.declination(atLatitude: coord.latitude,
-                                               longitude: coord.longitude,
-                                               altitude: 0)
-                XCTAssertEqual(geo.declination, result, accuracy: 0.1)
-                continue
-            }
-            #endif
             XCTAssertEqual(geo.declination, expected, accuracy: 0.1)
         }
     }


### PR DESCRIPTION
## Summary
- rely only on `Geomagnetism` to compute magnetic declination
- update tests to remove `CLGeomagneticModel`

## Testing
- `swift test -l` *(fails: unable to access 'https://github.com/apple/swift-testing.git')*

------
https://chatgpt.com/codex/tasks/task_e_68591ee018b48326836a3f8dfb3fc85b