### PR TITLE
Persist last magnetic declination

### DIFF
--- a/GPS Logger/LocationManager.swift
+++ b/GPS Logger/LocationManager.swift
@@ -54,6 +54,14 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
         self.settings = settings
         super.init()
 
+        // 保存された磁気偏差情報を復元
+        self.declination = settings.lastDeclination
+        if let data = settings.declinationLocation,
+           let savedLoc = try? NSKeyedUnarchiver.unarchivedObject(ofClass: CLLocation.self, from: data) {
+            self.declinationLocation = savedLoc
+        }
+        self.declinationTimestamp = settings.declinationTimestamp
+
         UIDevice.current.isBatteryMonitoringEnabled = true
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
@@ -246,6 +254,13 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
             declination = MagneticVariation.declination(at: loc.coordinate)
             declinationLocation = loc
             declinationTimestamp = Date()
+            settings.lastDeclination = declination
+            if let data = try? NSKeyedArchiver.archivedData(withRootObject: loc, requiringSecureCoding: true) {
+                settings.declinationLocation = data
+            } else {
+                settings.declinationLocation = nil
+            }
+            settings.declinationTimestamp = declinationTimestamp
         }
     }
 }

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -72,6 +72,13 @@ final class Settings: ObservableObject {
     /// Night テーマを使用するかどうか
     @UserDefaultBacked(key: "useNightTheme") var useNightTheme: Bool = false
 
+    /// 前回計算した磁気偏差
+    @UserDefaultBacked(key: "lastDeclination") var lastDeclination: Double = 0.0
+    /// 磁気偏差計算地点
+    @UserDefaultBacked(key: "declinationLocation") var declinationLocation: Data?
+    /// 磁気偏差計算日時
+    @UserDefaultBacked(key: "declinationTimestamp") var declinationTimestamp: Date?
+
     init() {
         $logInterval
             .receive(on: DispatchQueue.main)
@@ -154,6 +161,11 @@ final class Settings: ObservableObject {
             .store(in: &cancellables)
 
         $useNightTheme
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        $lastDeclination
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary
- store the last calculated magnetic declination in `Settings`
- restore saved declination info when initializing `LocationManager`
- save updated declination and its location/timestamp back to `Settings`

## Testing
- `swift test --enable-test-discovery` *(fails: cannot fetch remote package)*

------
https://chatgpt.com/codex/tasks/task_e_68592d4f12588326bc1bf8923b83cf12