### PR TITLE
Fix compile issues in Settings and RangeRingOverlay

### DIFF
--- a/GPS Logger/Map/RangeRingOverlay.swift
+++ b/GPS Logger/Map/RangeRingOverlay.swift
@@ -119,7 +119,7 @@ final class RangeRingRenderer: MKOverlayRenderer {
             path.move(to: CGPoint(x: 0, y: -compassRadius))
             path.addLine(to: CGPoint(x: 0, y: -compassRadius + len))
 
-            var transform = CGAffineTransform(rotationAngle: CGFloat((Double(deg) + heading) * .pi / 180))
+            let transform = CGAffineTransform(rotationAngle: CGFloat((Double(deg) + heading) * .pi / 180))
             path.apply(transform)
 
             var labelPos: CGPoint? = nil

--- a/GPS Logger/Settings.swift
+++ b/GPS Logger/Settings.swift
@@ -46,10 +46,10 @@ final class Settings: ObservableObject {
         var id: Self { self }
         var label: String {
             switch self {
-            case .northUp: "North UP"
-            case .trackUp: "Track UP"
-            case .magneticUp: "Magnetic UP"
-            case .manual: "Free Rotate"
+            case .northUp: return "North UP"
+            case .trackUp: return "Track UP"
+            case .magneticUp: return "Magnetic UP"
+            case .manual: return "Free Rotate"
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix `label` accessor of MapOrientationMode to use `return`
- make `transform` constant in RangeRingOverlay

## Testing
- `swift test -c debug` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68592f388c1c8326816e7d9e4f149a7e