### PR TITLE
Update map overlay rendering

### DIFF
--- a/GPS Logger/Map/RangeRingOverlay.swift
+++ b/GPS Logger/Map/RangeRingOverlay.swift
@@ -157,18 +157,18 @@ final class RangeRingRenderer: MKOverlayRenderer {
         context.translateBy(x: centerPt.x, y: centerPt.y)
 
         context.setStrokeColor(ringColor.cgColor)
-        context.setLineWidth(1.0 / zoomScale)
+        context.setLineWidth(3.0 / zoomScale)
         context.addPath(ringPath.cgPath)
         context.strokePath()
 
         for tick in ticks {
-            context.setLineWidth(tick.width / zoomScale)
+            context.setLineWidth(tick.width * 3 / zoomScale)
             context.addPath(tick.path.cgPath)
             context.strokePath()
         }
 
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 12),
+            .font: UIFont.systemFont(ofSize: 36),
             .foregroundColor: ringColor,
             .backgroundColor: UIColor.black.withAlphaComponent(0.5)
         ]

--- a/GPS Logger/Map/TrackVectorOverlay.swift
+++ b/GPS Logger/Map/TrackVectorOverlay.swift
@@ -66,7 +66,7 @@ final class TrackVectorRenderer: MKOverlayRenderer {
             let len = hypot(vec.x, vec.y)
             let unit = CGPoint(x: vec.x / len, y: vec.y / len)
             let perp = CGPoint(x: -unit.y, y: unit.x)
-            let headLen: CGFloat = 10 / zoomScale
+            let headLen: CGFloat = 30 / zoomScale
             let p1 = CGPoint(x: arrowPt.x - unit.x * headLen + perp.x * headLen/2,
                              y: arrowPt.y - unit.y * headLen + perp.y * headLen/2)
             let p2 = CGPoint(x: arrowPt.x - unit.x * headLen - perp.x * headLen/2,
@@ -80,15 +80,15 @@ final class TrackVectorRenderer: MKOverlayRenderer {
                 let markCoord = GeodesicCalculator.destinationPoint(from: overlayObj.coordinate, courseDeg: overlayObj.courseDeg, distanceNm: dist)
                 let markPt = point(for: MKMapPoint(markCoord))
                 path.move(to: markPt)
-                path.addEllipse(in: CGRect(x: markPt.x - 3, y: markPt.y - 3, width: 6, height: 6))
+                path.addEllipse(in: CGRect(x: markPt.x - 9, y: markPt.y - 9, width: 18, height: 18))
             }
         }
 
         let trackHex = settings.useNightTheme ? Color("TrackNight", bundle: .module).hexString
                                              : Color("TrackDay", bundle: .module).hexString
         let stroke = UIColor(hex: trackHex) ?? .yellow
-        context.setStrokeColor(stroke.withAlphaComponent(0.5).cgColor)
-        context.setLineWidth(2.0 / zoomScale)
+        context.setStrokeColor(stroke.cgColor)
+        context.setLineWidth(6.0 / zoomScale)
         context.addPath(path)
         context.strokePath()
     }


### PR DESCRIPTION
## Summary
- 境界線やメモリ線の線幅を拡大
- ラベル用フォントを36ptに変更
- 進路矢印の大きさとマーク円を拡大
- トラックベクトルの描画を不透明化し線幅を太く

## Testing
- `swift test` *(失敗: ネットワークアクセスが制限されているため依存パッケージを取得できず)*

------
https://chatgpt.com/codex/tasks/task_e_685f9c95670883269c42d9ef514e44cd