### PR TITLE
Disable camera auto-update during free scroll

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -573,6 +573,9 @@ struct MapViewRepresentable: UIViewRepresentable {
             guard let mapView,
                   let loc = locationManager.lastLocation else { return }
 
+            // フリースクロール中はカメラの自動更新を行わない
+            if freeScroll.wrappedValue { return }
+
             DispatchQueue.main.async {
                 let cam = mapView.camera
                 // ズーム距離を設定


### PR DESCRIPTION
## Summary
- stop updating camera automatically while `freeScroll` is active

## Testing
- `swift test --enable-code-coverage` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f9e7f27508326bed9e438a247b49f