### PR TITLE
Disable map bounce in map view

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -159,6 +159,9 @@ struct MapViewRepresentable: UIViewRepresentable {
 
     func makeUIView(context: Context) -> MKMapView {
         let map = MKMapView(frame: .zero)
+        if let scrollView = map.subviews.first(where: { $0 is UIScrollView }) as? UIScrollView {
+            scrollView.bounces = false
+        }
         map.showsUserLocation = true
         map.delegate = context.coordinator
         map.isZoomEnabled = false
@@ -214,6 +217,9 @@ struct MapViewRepresentable: UIViewRepresentable {
         context.coordinator.overlayIDs = targetIDs
 
         map.isScrollEnabled = freeScroll
+        if let scrollView = map.subviews.first(where: { $0 is UIScrollView }) as? UIScrollView {
+            scrollView.bounces = false
+        }
         // isPitchEnabled は設定変更で再有効化されないよう毎回 false を指定
         map.isPitchEnabled = false
 


### PR DESCRIPTION
## Summary
- バウンス抑止のため `UIScrollView` の `bounces` を無効化しました
- 更新時にも同様の処理を追加しました

## Testing
- `swift test` *(failed: unable to clone dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6860816e56848326af0ce38b1ea79b9e