### PR TITLE
Fix tuple returns in AirspaceManager

### DIFF
--- a/GPS Logger/Airspace/AirspaceManager.swift
+++ b/GPS Logger/Airspace/AirspaceManager.swift
@@ -203,12 +203,12 @@ final class AirspaceManager: ObservableObject, AirspaceSlimBuilder {
     private func loadOverlays(from url: URL, category: String) -> (overlays: [MKOverlay], groups: [String: [MKOverlay]], annotations: [FacilityAnnotation]) {
         guard let data = try? Data(contentsOf: url) else {
             Logger.airspace.debug("Could not read data from \(url.path)")
-            return ([], [:])
+            return ([], [:], [])
         }
         guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let features = obj["features"] as? [[String: Any]] else {
             Logger.airspace.debug("Invalid GeoJSON: \(url.lastPathComponent)")
-            return ([], [:])
+            return ([], [:], [])
         }
 
         var loaded: [MKOverlay] = []


### PR DESCRIPTION
## Summary
- fix early returns for `loadOverlays(from:category:)`

## Testing
- `swift build` *(fails: unable to fetch dependency)*
- `swift test` *(fails: unable to fetch dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6863cf620f588326a72a6f9fae891379