### PR TITLE
Fix RangeRing label scaling with zoom

### DIFF
--- a/GPS Logger/Map/RangeRingOverlay.swift
+++ b/GPS Logger/Map/RangeRingOverlay.swift
@@ -168,7 +168,8 @@ final class RangeRingRenderer: MKOverlayRenderer {
         }
 
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: UIFont.systemFont(ofSize: 36),
+            // ズームによってラベルサイズが変化しないよう調整
+            .font: UIFont.systemFont(ofSize: 36 / zoomScale),
             .foregroundColor: ringColor,
             .backgroundColor: UIColor.black.withAlphaComponent(0.5)
         ]


### PR DESCRIPTION
## Summary
- update `RangeRingRenderer` to scale label fonts with the map's zoom level

## Testing
- `swift test` *(fails: unable to fetch `swift-testing` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68644c2f43408326a567e95b6240848f