### PR TITLE
Fix compass label radius

### DIFF
--- a/GPS Logger/Map/RangeRingOverlay.swift
+++ b/GPS Logger/Map/RangeRingOverlay.swift
@@ -97,7 +97,6 @@ final class RangeRingRenderer: MKOverlayRenderer {
         let midLen = majorLen * 2.0 / 3.0
         let tenLen = majorLen * 0.5
         let minorLen = majorLen * 0.3
-        let outerLabelRadius = radius + labelOffset
         let midLabelRadius = compassRadius - labelOffset
 
         for deg in stride(from: 0, to: 360, by: 5) {
@@ -127,7 +126,7 @@ final class RangeRingRenderer: MKOverlayRenderer {
 
             var labelPos: CGPoint? = nil
             if let _ = label {
-                let r = (deg % 90 == 0) ? outerLabelRadius : midLabelRadius
+                let r = midLabelRadius
                 var p = CGPoint(x: 0, y: -r)
                 p = p.applying(transform)
                 labelPos = p


### PR DESCRIPTION
## Summary
- always use `midLabelRadius` for tick labels in RangeRingOverlay
- remove unused `outerLabelRadius`

## Testing
- `swift test -v` *(fails: Failed to clone repository https://github.com/apple/swift-testing.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_686453e535608326a715494cd1449579