### PR TITLE
Rotate range ring labels with map heading

### DIFF
--- a/GPS Logger/Map/MainMapView.swift
+++ b/GPS Logger/Map/MainMapView.swift
@@ -530,6 +530,14 @@ struct MapViewRepresentable: UIViewRepresentable {
                     airspaceManager.updateMapRect(rect)
                 }
             }
+
+            if let ring = rangeOverlay {
+                ring.update(center: ring.coordinate,
+                            radiusNm: ring.radiusNm,
+                            courseDeg: ring.courseDeg,
+                            mapHeading: mapView.camera.heading)
+                rendererCache[ObjectIdentifier(ring)]?.setNeedsDisplay()
+            }
         }
 
         func mapViewDidChangeVisibleRegion(_ mapView: MKMapView) {
@@ -600,15 +608,27 @@ struct MapViewRepresentable: UIViewRepresentable {
                 if dist > ring.radiusNm * 10 || ratio >= 3 {
                     mapView.removeOverlay(ring)
                     rendererCache.removeValue(forKey: ObjectIdentifier(ring))
-                    let newRing = RangeRingOverlay(center: loc.coordinate, radiusNm: rangeNm, courseDeg: course)
+                    let heading = mapView.camera.heading
+                    let newRing = RangeRingOverlay(center: loc.coordinate,
+                                                 radiusNm: rangeNm,
+                                                 courseDeg: course,
+                                                 mapHeading: heading)
                     rangeOverlay = newRing
                     mapView.addOverlay(newRing, level: .aboveLabels)
                 } else {
-                    ring.update(center: loc.coordinate, radiusNm: rangeNm, courseDeg: course)
+                    let heading = mapView.camera.heading
+                    ring.update(center: loc.coordinate,
+                                radiusNm: rangeNm,
+                                courseDeg: course,
+                                mapHeading: heading)
                     rendererCache[ObjectIdentifier(ring)]?.setNeedsDisplay()
                 }
             } else {
-                let ring = RangeRingOverlay(center: loc.coordinate, radiusNm: rangeNm, courseDeg: course)
+                let heading = mapView.camera.heading
+                let ring = RangeRingOverlay(center: loc.coordinate,
+                                            radiusNm: rangeNm,
+                                            courseDeg: course,
+                                            mapHeading: heading)
                 rangeOverlay = ring
                 mapView.addOverlay(ring, level: .aboveLabels)
             }
@@ -680,6 +700,14 @@ struct MapViewRepresentable: UIViewRepresentable {
                 }
                 mapView.setCamera(cam, animated: false)
                 mapView.isRotateEnabled = (self.settings.orientationMode == .manual)
+
+                if let ring = self.rangeOverlay {
+                    ring.update(center: ring.coordinate,
+                                radiusNm: ring.radiusNm,
+                                courseDeg: ring.courseDeg,
+                                mapHeading: cam.heading)
+                    self.rendererCache[ObjectIdentifier(ring)]?.setNeedsDisplay()
+                }
             }
         }
 

--- a/GPS Logger/Map/RangeRingOverlay.swift
+++ b/GPS Logger/Map/RangeRingOverlay.swift
@@ -6,24 +6,34 @@ final class RangeRingOverlay: NSObject, MKOverlay {
     var coordinate: CLLocationCoordinate2D
     var radiusNm: Double
     var courseDeg: Double
+    /// カメラの heading 値 (地図の回転角)
+    var mapHeading: Double
     private(set) var lastHeading: Double
     /// ラベルまで含めて描画するため、半径に少し余裕を持たせる
     private let marginRatio = 1.1
 
-    func update(center: CLLocationCoordinate2D, radiusNm: Double, courseDeg: Double) {
+    func update(center: CLLocationCoordinate2D,
+                radiusNm: Double,
+                courseDeg: Double,
+                mapHeading: Double) {
         self.coordinate = center
         self.radiusNm = radiusNm
         self.courseDeg = courseDeg
+        self.mapHeading = mapHeading
         let newHeading = MagneticVariation.declination(at: center)
         if abs(newHeading - lastHeading) >= 1 {
             lastHeading = newHeading
         }
     }
 
-    init(center: CLLocationCoordinate2D, radiusNm: Double, courseDeg: Double) {
+    init(center: CLLocationCoordinate2D,
+         radiusNm: Double,
+         courseDeg: Double,
+         mapHeading: Double) {
         self.coordinate = center
         self.radiusNm = radiusNm
         self.courseDeg = courseDeg
+        self.mapHeading = mapHeading
         self.lastHeading = MagneticVariation.declination(at: center)
         super.init()
     }
@@ -166,6 +176,9 @@ final class RangeRingRenderer: MKOverlayRenderer {
             context.addPath(tick.path.cgPath)
             context.strokePath()
         }
+
+        // テキスト描画時は地図の回転に合わせる
+        context.rotate(by: CGFloat(overlayObj.mapHeading * .pi / 180))
 
         let attrs: [NSAttributedString.Key: Any] = [
             // ズームによってラベルサイズが変化しないよう調整


### PR DESCRIPTION
## Summary
- hold map rotation (camera heading) in `RangeRingOverlay`
- pass current map heading to range ring updates
- rotate label drawing context by the map heading so that text follows map rotation

## Testing
- `swift test --enable-code-coverage` *(fails: cannot fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68645940bc6c832695bdb77bd746b4db